### PR TITLE
[CI] Support ver/* branches in module build workflow

### DIFF
--- a/.github/workflows/build-module.yaml
+++ b/.github/workflows/build-module.yaml
@@ -12,6 +12,7 @@ on:
   push:
     branches:
       - stable
+      - ver/*
     paths:
       - '.github/workflows/build-module.yaml'
       - 'Module/**/*'
@@ -42,7 +43,7 @@ jobs:
         run: bazel --output_user_root="C:\bz" build --config=release Kyber
 
       - name: Download Dependencies
-        if: github.ref == 'refs/heads/stable' || github.event_name == 'workflow_dispatch'
+        if: github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/heads/ver/') || github.event_name == 'workflow_dispatch'
         working-directory: ${{env.working-directory}}
         run: |
           New-Item -Path _work -ItemType Directory
@@ -52,7 +53,7 @@ jobs:
         shell: powershell
 
       - name: Setup Sentry CLI
-        if: github.ref == 'refs/heads/stable' || github.event_name == 'workflow_dispatch'
+        if: github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/heads/ver/') || github.event_name == 'workflow_dispatch'
         uses: mathieu-bour/setup-sentry-cli@v2
         with:
           token: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -61,27 +62,27 @@ jobs:
           project: module
 
       - name: Upload PDB
-        if: github.ref == 'refs/heads/stable' || github.event_name == 'workflow_dispatch'
+        if: github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/heads/ver/') || github.event_name == 'workflow_dispatch'
         working-directory: ${{env.working-directory}}
         run: |
           sentry-cli debug-files upload --project module --include-sources bazel-bin/Kyber.pdb
         shell: powershell
 
       - name: Copy DLL
-        if: github.ref == 'refs/heads/stable' || github.event_name == 'workflow_dispatch'
+        if: github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/heads/ver/') || github.event_name == 'workflow_dispatch'
         working-directory: ${{env.working-directory}}
         run: |
           cp "bazel-bin/Kyber.dll" "_work/Kyber.dll"
 
       - name: Zip files
-        if: github.ref == 'refs/heads/stable' || github.event_name == 'workflow_dispatch'
+        if: github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/heads/ver/') || github.event_name == 'workflow_dispatch'
         working-directory: ${{env.working-directory}}
         run: |
           Compress-Archive -Path "_work/*" -DestinationPath kyber-module.zip
         shell: powershell
 
       - name: Upload Artifacts
-        if: github.ref == 'refs/heads/stable' || github.event_name == 'workflow_dispatch'
+        if: github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/heads/ver/') || github.event_name == 'workflow_dispatch'
         working-directory: ${{env.working-directory}}
         run: |
           $ProgressPreference = 'SilentlyContinue'


### PR DESCRIPTION
Update the workflow so `ver/*` branches run the full module build and publish artifacts for testing