### PR TITLE
[Module] Persistence cleanup, misc

### DIFF
--- a/Module/Public/Core/Memory.h
+++ b/Module/Public/Core/Memory.h
@@ -17,11 +17,11 @@ public:
     void free(void* mem);
 };
 
-#define FB_STATIC_ARENA ((MemoryArena*)0x143CF74E0)
-#define FB_GLOBAL_ARENA ((MemoryArena*)0x143CF74C0)
-#define FB_CLIENT_ARENA ((MemoryArena*)0x143CF89E0)
-#define FB_SERVER_ARENA ((MemoryArena*)0x143CFA7C0)
-#define FB_FIXUP_ARENA ((MemoryArena*)0x143D23E80)
+#define FB_STATIC_ARENA (reinterpret_cast<MemoryArena*>(0x143CF74E0))
+#define FB_GLOBAL_ARENA (reinterpret_cast<MemoryArena*>(0x143CF74C0))
+#define FB_CLIENT_ARENA (reinterpret_cast<MemoryArena*>(0x143CF89E0))
+#define FB_SERVER_ARENA (reinterpret_cast<MemoryArena*>(0x143CFA7C0))
+#define FB_FIXUP_ARENA (reinterpret_cast<MemoryArena*>(0x143D23E80))
 
 void InitializeEASTL();
 

--- a/Module/Public/Persistence/PersistenceDatabase.h
+++ b/Module/Public/Persistence/PersistenceDatabase.h
@@ -18,6 +18,14 @@
 
 namespace Kyber
 {
+class PersistentStorageTemplate
+{
+public:
+    KB_DECLARE_GAMEMEMBERFUNC_NOARGS(0x140A7B9D0, uint32_t, GetCount)
+    KB_DECLARE_GAMEMEMBERFUNC(0x1467D3220, const char*, GetName, (offset), uint32_t offset)
+    KB_DECLARE_GAMEMEMBERFUNC(0x1467D32D0, uint32_t, GetOffset, (name), const char* name)
+};
+
 class PersistentStorage
 {
 public:
@@ -33,8 +41,23 @@ public:
     Values m_values;
     char m_padding[0x70 - sizeof(Values)];
 
-    __declspec(align(16)) void* m_template;
+    __declspec(align(16)) PersistentStorageTemplate* m_template;
 };
+
+// Called BitArray, prefixed Fb to not clash
+class FbBitArray
+{
+public:
+    void* m_vtable;        // 0x00 // research: only 1 func it points to, i think freer
+    uint32_t* m_bits;      // 0x08
+    __int64 pad_0010;    // 0x10
+    int32_t m_size;      // 0x18
+    __int64 pad_0020[2]; // 0x20
+
+    KB_DECLARE_GAMEMEMBERFUNC_NOARGS(0x14545A710, void*, Ctor)
+    KB_DECLARE_GAMEMEMBERFUNC(0x1454600C0, void*, Init, (bitCount, arena), uint32_t bitCount, MemoryArena* arena)
+    KB_DECLARE_GAMEMEMBERFUNC(0x1401E71B0, void*, Destroy, (arena), MemoryArena* arena)
+}; // Size: 0x30
 
 class PersistenceDatabase
 {

--- a/Module/Public/SDK/SDK.h
+++ b/Module/Public/SDK/SDK.h
@@ -88,7 +88,7 @@ KB_DECLARE_TYPEINFO(QueryEntityResult, 0x14446A0A0);
 #define KB_DECLARE_GAMEMEMBERFUNC_NOARGS(ptr, returnType, name)                                                                            \
     returnType name()                                                                                                                      \
     {                                                                                                                                      \
-        return reinterpret_cast<returnType(__thiscall*)(void*)>(ptr)(this);                                                                \
+        return reinterpret_cast<returnType(__fastcall*)(void*)>(ptr)(this);                                                                \
     }
 
 struct TypeObject
@@ -1167,12 +1167,17 @@ class ServerGamePlayerExtent : public ServerPlayerExtent
 public:
     static PlayerExtentRegistration* s_registration;
 
+    // Research:
+    // +0xE60 is unlock bitarray
+
     KB_DECLARE_GAMEMEMBERFUNC_NOARGS(0x14686AC80, TypeObject*, GetCharacter)
     KB_DECLARE_GAMEMEMBERFUNC_NOARGS(0x1468843B0, TypeObject*, GetVehicle)
     KB_DECLARE_GAMEMEMBERFUNC_NOARGS(0x146875A70, bool, IsInVehicle)
     KB_DECLARE_GAMEMEMBERFUNC(0x140BE2C60, void, LeaveVehicle, (forceLeave, useExitPoint), bool forceLeave, bool useExitPoint)
     KB_DECLARE_GAMEMEMBERFUNC(0x140BDDFE0, bool, EnterVehicle, (vehicle, seatIndex), void* vehicle, unsigned int seatIndex)
     KB_DECLARE_GAMEMEMBERFUNC(0x146881270, void*, SetSelectedCustomizationAsset, (asset), DataContainer* asset)
+    KB_DECLARE_GAMEMEMBERFUNC(0x146872DF0, void*, InitUnlockArray, (bitCount), uint32_t bitCount)
+    KB_DECLARE_GAMEMEMBERFUNC(0x146881840, void*, SetUnlocks, (bitArray), void* bitArray)
 };
 
 class PersistenceServerPlayerExtent : public ServerPlayerExtent
@@ -1194,7 +1199,9 @@ public:
     int32_t m_deaths;
     int32_t unk3;
     int32_t unk4;
-    int32_t m_longestKillstreak;
+    int32_t m_longestKillstreak; // 0x68
+    char pad_006C[0x12C];
+    void* m_persistentStorage; // 0x198
 };
 
 class WSServerPlayerAbilityExtent : public ServerPlayerExtent
@@ -1403,7 +1410,7 @@ class NetworkableMessage : public Message
 {
 public:
     ServerConnection* serverConnection; // 0x30
-    void* clientConnection;             // 0x38
+    ClientConnection* clientConnection; // 0x38
     int32_t unk1;                       // 0x40
     int32_t initiator;                  // 0x44
     int32_t messageStream;              // 0x48

--- a/Module/Source/Core/Console.cpp
+++ b/Module/Source/Core/Console.cpp
@@ -639,8 +639,7 @@ Console::Console()
     BYTE ptch[] = { 0xEB };
     MemoryUtils::Patch(HOOK_OFFSET(0x1401D0D03), (void*)ptch, sizeof(ptch));
     MemoryUtils::Patch(HOOK_OFFSET(0x1401D0D5B), (void*)ptch, sizeof(ptch));
-    // ServerPlayerExtent4::setActiveKit
-    MemoryUtils::Patch(HOOK_OFFSET(0x141BCE55C), (void*)ptch, sizeof(ptch));
+    MemoryUtils::Patch(HOOK_OFFSET(0x141BCE55C), (void*)ptch, sizeof(ptch)); // ServerPlayerExtent4::setActiveKit
 
     RegisterConsoleCommand(&RestartCommand, "Restart");
     RegisterConsoleCommand(&LoadLevelCommand, "LoadLevel", "<level> <mode>");

--- a/Module/Source/Core/Memory.cpp
+++ b/Module/Source/Core/Memory.cpp
@@ -8,9 +8,6 @@
 
 #include <EASTL/internal/config.h>
 
-#define OFFSET_MEMORYARENA_ALLOC HOOK_OFFSET(0x14541CD00)
-#define OFFSET_MEMORYARENA_FREE HOOK_OFFSET(0x1401C8100)
-
 namespace Kyber
 {
 TL_DECLARE_FUNC(0x14541CD00, void*, MemoryArena_alloc, MemoryArena* arena, size_t size, size_t alignment);

--- a/Module/Source/Core/Program.cpp
+++ b/Module/Source/Core/Program.cpp
@@ -736,43 +736,6 @@ void MessageManagerDispatchMessageHk(void* inst, Message* message)
     trampoline(inst, message);
 }
 
-void UnkServerPlayerExtent_onNetworkMessageHk(void** inst, Message* message)
-{
-    static const auto trampoline = HookManager::Call(UnkServerPlayerExtent_onNetworkMessageHk);
-
-    if (message == nullptr || inst == nullptr)
-    {
-        trampoline(inst, message);
-        return;
-    }
-
-    //ServerPlayerExtent* realExtent = reinterpret_cast<ServerPlayerExtent*>(inst[-1]);
-
-    /*
-    TypeInfo* messageType = message->getType();
-    if (messageType == nullptr || messageType->typeInfoData == nullptr)
-    {
-        trampoline(inst, message);
-        return;
-    }
-
-    TypeInfo* extentType = inst->getType();
-    if (extentType == nullptr || extentType->typeInfoData == nullptr)
-    {
-        trampoline(inst, message);
-        return;
-    }
-
-    eastl::string name = messageType->getName();
-
-    KYBER_LOG(Debug, "Extent " << inst->getType()->getName() << " at "
-        << std::hex << inst << " with message " << message->getType()->getName() << " at " << std::hex << message);
-    */
-    //KYBER_LOG(Debug, "Extent " << std::hex << inst << " Message " << std::hex << message << " " << message->getType()->getName());
-
-    trampoline(inst, message);
-}
-
 const char* GetHostIdHk(__int64 inst)
 {
     return std::getenv("EALaunchEAID");
@@ -823,7 +786,7 @@ __int64 ClientUpdatePassPreFrameHk(void* inst, const UpdateParameters& params)
 
     g_threadExecutor->Process(GameThread_Client);
 
-    if (!g_program->m_server->m_runningHosted && !g_program->m_isDedicatedServer)
+    if (!g_program->m_server->IsRunning())
     {
         g_program->GetAPI()->Update();
     }
@@ -917,7 +880,6 @@ void Program::InitializeGameHooks()
         { OFFSET_CLIENT_UPDATEPASSPOSTFRAME, ClientUpdatePassPostFrameHk },
         { HOOK_OFFSET(0x1418D92B0), ClientAuthHk },
         { OFFSET_MEMORYARENA_LOG, MemoryArenaLog },
-        { HOOK_OFFSET(0x148E512F0), UnkServerPlayerExtent_onNetworkMessageHk },
         { HOOK_OFFSET(0x146A4BA30), TeamInfo__isFriendlyHk },
 
         // Dummy out unsafe built-in lua functions

--- a/Module/Source/Core/Server.cpp
+++ b/Module/Source/Core/Server.cpp
@@ -728,7 +728,7 @@ void ServerUpdatePassPreFrameHk(void* inst, const UpdateParameters& params)
     g_program->m_server->Heartbeat(params);
     g_threadExecutor->Process(GameThread_Server);
 
-    if (g_program->m_server->m_runningHosted || g_program->m_isDedicatedServer)
+    if (g_program->m_server->IsRunning())
     {
         g_program->GetAPI()->Update();
     }

--- a/Module/Source/Persistence/PersistenceManager.cpp
+++ b/Module/Source/Persistence/PersistenceManager.cpp
@@ -74,7 +74,7 @@ __int64 InitUnlockArrayHk(__int64 a1, ServerPlayer* player)
     // return trampoline(a1, player);
 
     ServerGamePlayerExtent* extent = player->GetServerGamePlayerExtent();
-    KYBER_LOG(Debug, "[Persistence] Initialized unlock array 1 " << player->m_name << " " << std::hex << extent);
+    KYBER_LOG(Debug, "[Persistence] Initialized unlock array " << player->m_name << " " << std::hex << extent);
     //__int64 result = trampoline(a1, serverPlayer);
 
     extent->InitUnlockArray(1217);

--- a/Module/Source/Persistence/PersistenceManager.cpp
+++ b/Module/Source/Persistence/PersistenceManager.cpp
@@ -14,10 +14,8 @@
 
 namespace Kyber
 {
-TL_DECLARE_FUNC(0x140A7B9D0, uint32_t, PersistentStorageTemplate_getCount, void* inst);
-TL_DECLARE_FUNC(0x1467D3220, const char*, PersistentStorageTemplate_getName, void* inst, uint32_t offset);
-TL_DECLARE_FUNC(0x1467D32D0, uint32_t, PersistentStorageTemplate_getOffset, void* inst, const char* name);
 TL_DECLARE_FUNC(0x1483EFEB0, __int64, ReplicatePersistence, void* inst, ServerPlayer* player);
+TL_DECLARE_FUNC(0x1483EA700, int32_t, ServerPersistenceUnlocksGetBitIndex, intptr_t inst, const Guid& guid);
 
 static const PlayerExtentRegistration* PersistentServerPlayerExtent_extentRegistration = (PlayerExtentRegistration*)0x143AB4900;
 
@@ -26,80 +24,42 @@ void LogPlayerStats(ConsoleContext& cc)
     KYBER_LOG(Info, "Player Manager: " << std::hex << g_program->m_server->m_playerManager);
     for (ServerPlayer* player : g_program->m_server->m_playerManager->m_players)
     {
-        if (player)
+        if (player != nullptr)
         {
-            KYBER_LOG(Info, "Offset: " << PersistentServerPlayerExtent_extentRegistration->offset);
-            TypeObject* extent = (TypeObject*)((__int64)player + PersistentServerPlayerExtent_extentRegistration->offset);
-            PersistentStorage* storage = *(PersistentStorage**)((__int64)extent + 0x198);
+            KYBER_LOG(Info, "Offset: " << PersistenceServerPlayerExtent::s_registration->offset);
+            PersistenceServerPlayerExtent* extent = player->GetPersistenceServerPlayerExtent();
+            PersistentStorage* storage = static_cast<PersistentStorage*>(extent->m_persistentStorage);
             KYBER_LOG(Info, "Offset: " << offsetof(PersistentStorage, m_template) << " " << std::hex << player << " " << extent << " "
-                                       << (((__int64)player) + 10800));
+                                       << (((__int64)player) + 10800)); // no i do not know what +10800 is for
 
-            uint32_t offset = PersistentStorageTemplate_getOffset(storage->m_template, "c_cta__crax_ghva");
+            uint32_t offset = storage->m_template->GetOffset("c_cta__crax_ghva");
 
             PersistentStorage::Value& value = storage->m_values[offset];
             KYBER_LOG(Info, "Player: " << player->m_name << " " << value.current);
         }
     }
 }
-
-__int64 BitArrayCtorHk(__int64 inst)
-{
-    static const auto trampoline = HookManager::Call(BitArrayCtorHk);
-    return trampoline(inst);
-}
-
-__int64 BitArrayInitHk(__int64 inst, uint32_t bitCount, MemoryArena* arena)
-{
-    static const auto trampoline = HookManager::Call(BitArrayInitHk);
-    return trampoline(inst, bitCount, arena);
-}
-
-__int64 BitArrayDestroyHk(__int64 inst, MemoryArena* arena)
-{
-    static const auto trampoline = HookManager::Call(BitArrayDestroyHk);
-    return trampoline(inst, arena);
-}
-
-__int64 ServerGamePlayerExtentSetUnlocksHk(__int64 a1, __int64 a2)
-{
-    static const auto trampoline = HookManager::Call(ServerGamePlayerExtentSetUnlocksHk);
-    return trampoline(a1, a2);
-}
-
-void* ServerGamePlayerExtentInitUnlockArrayHk(__int64 inst, uint32_t bitCount)
-{
-    static const auto trampoline = HookManager::Call(ServerGamePlayerExtentInitUnlockArrayHk);
-    return trampoline(inst, bitCount);
-}
-
-int32_t ServerPersistenceUnlocksGetBitIndexHk(__int64 inst, const Guid& guid)
-{
-    static const auto trampoline = HookManager::Call(ServerPersistenceUnlocksGetBitIndexHk);
-    return trampoline(inst, guid);
-}
-
 void ServerPlayerSetUnlock(ServerPlayer* player, const Guid& guid, bool value)
 {
-    __int64 extent = (__int64)player->GetExtent("ServerGamePlayerExtent");
+    ServerGamePlayerExtent* extent = player->GetServerGamePlayerExtent();
 
-    ServerGamePlayerExtentInitUnlockArrayHk(extent, 1217);
-    __int64 bitArray = (__int64)new __int64[6];
-    BitArrayCtorHk(bitArray);
-    BitArrayInitHk(bitArray, 1217, nullptr);
-    memcpy(*reinterpret_cast<void**>(bitArray + 8), reinterpret_cast<void*>(extent + 0xE60),
-        static_cast<size_t>(4) * *reinterpret_cast<unsigned int*>(bitArray + 0x18));
+    extent->InitUnlockArray(1217);
+    FbBitArray* bitArray = reinterpret_cast<FbBitArray*>(FB_SERVER_ARENA->alloc(sizeof(FbBitArray)));
+    bitArray->Ctor();
+    bitArray->Init(1217, nullptr);
+    memcpy(bitArray->m_bits, reinterpret_cast<void*>(extent + 0xE60), 4 * bitArray->m_size);
 
-    uint32_t index = ServerPersistenceUnlocksGetBitIndexHk(*reinterpret_cast<__int64*>(0x143ED4480), guid);
+    uint32_t index = ServerPersistenceUnlocksGetBitIndex(*reinterpret_cast<__int64*>(0x143ED4480), guid);
 
-    uint32_t* bits = *(uint32_t**)(bitArray + 8);
+    uint32_t* bits = bitArray->m_bits;
     uint32_t elementIndex = index / 32;
     uint32_t bitMask = 1U << (index % 32);
     bits[elementIndex] ^= (bits[elementIndex] ^ static_cast<uint32_t>(-static_cast<int>(value))) & bitMask;
 
-    ServerGamePlayerExtentSetUnlocksHk(extent, bitArray);
+    extent->SetUnlocks(bitArray);
 
-    BitArrayDestroyHk(bitArray, nullptr);
-    delete[] (__int64*)bitArray;
+    bitArray->Destroy(nullptr);
+    FB_SERVER_ARENA->free(bitArray);
 }
 
 __int64 InitUnlockArrayHk(__int64 a1, ServerPlayer* player)
@@ -113,20 +73,21 @@ __int64 InitUnlockArrayHk(__int64 a1, ServerPlayer* player)
     // Uncomment to disable everything being unlocked
     // return trampoline(a1, player);
 
-    __int64 extent = (__int64)player->GetExtent("ServerGamePlayerExtent");
-    KYBER_LOG(Info, "[Persistence] Initialized unlock array 1 " << player->m_name << " " << std::hex << extent);
+    ServerGamePlayerExtent* extent = player->GetServerGamePlayerExtent();
+    KYBER_LOG(Debug, "[Persistence] Initialized unlock array 1 " << player->m_name << " " << std::hex << extent);
     //__int64 result = trampoline(a1, serverPlayer);
 
-    ServerGamePlayerExtentInitUnlockArrayHk(extent, 1217);
-    __int64 bitArray = (__int64)new __int64[6];
-    BitArrayCtorHk(bitArray);
-    BitArrayInitHk(bitArray, 1217, nullptr);
-    memset(*(void**)(bitArray + 8), 0xFFFFFFFF, 4 * *(unsigned int*)(bitArray + 0x18));
+    extent->InitUnlockArray(1217);
+    
+    FbBitArray* bitArray = reinterpret_cast<FbBitArray*>(FB_SERVER_ARENA->alloc(sizeof(FbBitArray)));
+    bitArray->Ctor();
+    bitArray->Init(1217, nullptr);
+    memset(bitArray->m_bits, 0xFFFFFFFF, 4 * bitArray->m_size);
 
-    ServerGamePlayerExtentSetUnlocksHk(extent, bitArray);
+    extent->SetUnlocks(bitArray);
 
-    BitArrayDestroyHk(bitArray, nullptr);
-    delete[] (__int64*)bitArray;
+    bitArray->Destroy(nullptr);
+    FB_SERVER_ARENA->free(bitArray);
     // return result;
     return 0;
 }
@@ -153,14 +114,14 @@ PlayerStatsMap ExtractPlayerStats(ServerPlayer* player)
         return stats;
     }
 
-    TypeObject* extent = (TypeObject*)((__int64)player + PersistentServerPlayerExtent_extentRegistration->offset);
-    PersistentStorage* storage = *(PersistentStorage**)((__int64)extent + 0x198);
+    PersistenceServerPlayerExtent* extent = player->GetPersistenceServerPlayerExtent();
+    PersistentStorage* storage = static_cast<PersistentStorage*>(extent->m_persistentStorage);
 
-    uint32_t count = PersistentStorageTemplate_getCount(storage->m_template);
+    uint32_t count = storage->m_template->GetCount();
     for (uint32_t i = 0; i < count; i++)
     {
-        const char* name = PersistentStorageTemplate_getName(storage->m_template, i);
-        uint32_t offset = PersistentStorageTemplate_getOffset(storage->m_template, name);
+        const char* name = storage->m_template->GetName(i);
+        uint32_t offset = storage->m_template->GetOffset(name);
         PersistentStorage::Value& value = storage->m_values[offset];
         if (!(fabsf(value.current - value.reference) > 0.000001))
         {
@@ -175,8 +136,8 @@ PlayerStatsMap ExtractPlayerStats(ServerPlayer* player)
 
 void ApplyPlayerStats(void* inst, ServerPlayer* player, const PlayerStatsMap& stats)
 {
-    TypeObject* extent = (TypeObject*)((__int64)player + PersistentServerPlayerExtent_extentRegistration->offset);
-    PersistentStorage* storage = *(PersistentStorage**)((__int64)extent + 0x198);
+    PersistenceServerPlayerExtent* extent = player->GetPersistenceServerPlayerExtent();
+    PersistentStorage* storage = static_cast<PersistentStorage*>(extent->m_persistentStorage);
     if (storage == nullptr)
     {
         return;
@@ -184,7 +145,7 @@ void ApplyPlayerStats(void* inst, ServerPlayer* player, const PlayerStatsMap& st
 
     for (const auto& entry : stats)
     {
-        uint32_t offset = PersistentStorageTemplate_getOffset(storage->m_template, entry.first.c_str());
+        uint32_t offset = storage->m_template->GetOffset(entry.first.c_str());
         if (offset == 0xFFFFFFFF)
         {
             continue;
@@ -197,16 +158,8 @@ void ApplyPlayerStats(void* inst, ServerPlayer* player, const PlayerStatsMap& st
     ReplicatePersistence(inst, player);
 }
 
-void LoadPlayerDataCommand(ConsoleContext& cc)
-{
-    static const auto trampoline = HookManager::Call(LoadPlayerPersistenceHk);
-    // trampoline(persistenceInst, g_program->m_server->m_playerManager->m_players[0]);
-}
-
 void SavePlayerDataCommand(ConsoleContext& cc)
 {
-    static const auto trampoline = HookManager::Call(LoadPlayerPersistenceHk);
-
     auto stream = cc.stream();
     std::string playerName;
     stream >> playerName;
@@ -285,12 +238,6 @@ void PersistenceManager::Initialize()
 {
     HookTemplate hookOffsets[] = {
         { HOOK_OFFSET(0x1418A81A0), InitUnlockArrayHk },
-        { HOOK_OFFSET(0x146872DF0), ServerGamePlayerExtentInitUnlockArrayHk },
-        { HOOK_OFFSET(0x14545A710), BitArrayCtorHk },
-        { HOOK_OFFSET(0x1454600C0), BitArrayInitHk },
-        { HOOK_OFFSET(0x1401E71B0), BitArrayDestroyHk },
-        { HOOK_OFFSET(0x146881840), ServerGamePlayerExtentSetUnlocksHk },
-        { HOOK_OFFSET(0x1483EA700), ServerPersistenceUnlocksGetBitIndexHk },
         { HOOK_OFFSET(0x1483F0160), LoadPlayerPersistenceHk },
     };
 
@@ -305,7 +252,6 @@ void PersistenceManager::Initialize()
         RegisterConsoleCommand(&LogPlayerStats, "LogPlayerStats");
         RegisterConsoleCommand(&GrantUnlockCommand, "GrantUnlock", "<player> <guid>");
         RegisterConsoleCommand(&RevokeUnlockCommand, "RevokeUnlock", "<player> <guid>");
-        RegisterConsoleCommand(&LoadPlayerDataCommand, "LoadData");
         RegisterConsoleCommand(&SavePlayerDataCommand, "SaveData");
     });
 

--- a/Module/Source/SDK/SDK.cpp
+++ b/Module/Source/SDK/SDK.cpp
@@ -31,8 +31,8 @@ TL_DECLARE_FUNC(0x141128770, bool, SimpleEntityOwner_internalDestroyEntity, void
 TL_DECLARE_FUNC(0x1470BC9B0, bool, SimpleEntityOwner_destroyOwnedEntities, void* inst, Realm realm);
 TL_DECLARE_FUNC(0x1470BC620, void, SimpleEntityOwner_deinitOwnedEntities, void* inst, void* info);
 
-typedef __int64(__fastcall* SpatialEntity_getTransform)(const void* inst, LinearTransform& transform);
-typedef __int64(__fastcall* SpatialEntity_setTransform)(void* inst, const LinearTransform& transform);
+typedef __int64(__fastcall* SpatialEntity_getTransform_t)(const void* inst, LinearTransform& transform);
+typedef __int64(__fastcall* SpatialEntity_setTransform_t)(void* inst, const LinearTransform& transform);
 
 TL_DECLARE_FUNC(0x14116F610, bool, Entity_init, NativeEntity* inst, EntityInitInfo* info);
 TL_DECLARE_FUNC(0x1469DAF40, EntityInitInfo*, EntityInitInfo_ctor, EntityInitInfo* inst, Realm realm, void* context);
@@ -368,7 +368,7 @@ void NativeEntity::Init()
 
 void SpatialEntity::GetTransform(LinearTransform& transform) const
 {
-    auto func = reinterpret_cast<SpatialEntity_getTransform>(PlatformUtils::GetVTableFunction(this, 27));
+    auto func = reinterpret_cast<SpatialEntity_getTransform_t>(PlatformUtils::GetVTableFunction(this, 27));
 
     // Same reason as raycast vecs being heap allocated
     LinearTransform* trans = new LinearTransform();
@@ -379,7 +379,7 @@ void SpatialEntity::GetTransform(LinearTransform& transform) const
 
 void SpatialEntity::SetTransform(const LinearTransform& transform)
 {
-    auto func = reinterpret_cast<SpatialEntity_setTransform>(PlatformUtils::GetVTableFunction(this, 28));
+    auto func = reinterpret_cast<SpatialEntity_setTransform_t>(PlatformUtils::GetVTableFunction(this, 28));
 
     // See above
     LinearTransform* trans = new LinearTransform(transform);

--- a/Module/Source/Script/LuaPlayerManager.cpp
+++ b/Module/Source/Script/LuaPlayerManager.cpp
@@ -677,7 +677,7 @@ Asset* GetWSPlayerAbilityFromCustomizationAssetHk(ServerPlayer* player, uint32_t
     Asset* asset = getWsPlayerAbilityAsset(abilityId);
     if (asset != nullptr)
     {
-        KYBER_LOG(Info, "getWsPlayerAbilityAsset: " << asset->Name);
+        KYBER_LOG(Debug, "getWsPlayerAbilityAsset: " << asset->Name);
     }
     return asset;
 }

--- a/Module/build.bat
+++ b/Module/build.bat
@@ -1,2 +1,2 @@
-bazel --output_user_root="C:\bz" build --config=debug Kyber
+bazel --output_user_root="C:\bz" build --config=release Kyber
 xcopy /y /f ".\bazel-bin/Kyber.dll" "%ProgramData%/Kyber/Module/Kyber.dll"

--- a/Module/build.bat
+++ b/Module/build.bat
@@ -1,2 +1,2 @@
-bazel --output_user_root="C:\bz" build --config=release Kyber
+bazel --output_user_root="C:\bz" build --config=debug Kyber
 xcopy /y /f ".\bazel-bin/Kyber.dll" "%ProgramData%/Kyber/Module/Kyber.dll"


### PR DESCRIPTION
- Big cleanup of the persistence manager
- Removed more unused debugging stuff
- Made log that shouldn't have been `Info` `Debug`
- Fixed `KB_DECLARE_GAMEMEMBERFUNC_NOARGS` to have `fastcall` calling convention
- Simplified some checks