### PR TITLE
[API, Launcher] Add token reset flow

### DIFF
--- a/API/internal/rpc/authentication.go
+++ b/API/internal/rpc/authentication.go
@@ -369,6 +369,20 @@ func (s *AuthenticationServer) Verify(ctx context.Context, _ *pbcommon.Empty) (*
 	}, nil
 }
 
+func (s *AuthenticationServer) ResetToken(ctx context.Context, _ *pbcommon.Empty) (*pbcommon.Empty, error) {
+	user := ctx.Value("user").(*models.UserModel)
+
+	token := util.GenerateToken()
+
+	err := s.store.Users.Update(ctx, user.ID, bson.M{"$set": bson.M{"token": token}})
+	if err != nil {
+		logger.L().Error("Failed to update user token", zap.Error(err))
+		return nil, status.Error(codes.Internal, "Failed to reset token")
+	}
+
+	return &pbcommon.Empty{}, nil
+}
+
 func (s *AuthenticationServer) Login(ctx context.Context, req *pbapi.LoginRequest) (*pbapi.LoginResponse, error) {
 	meta, exist := metadata.FromIncomingContext(ctx)
 	if !exist {

--- a/Launcher/lib/features/settings/dialogs/reset_token_dialog.dart
+++ b/Launcher/lib/features/settings/dialogs/reset_token_dialog.dart
@@ -1,0 +1,41 @@
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:kyber_launcher/shared/ui/buttons/button.dart';
+import 'package:kyber_launcher/shared/ui/dialog/kyber_dialog.dart';
+
+class ResetTokenDialog extends StatefulWidget {
+  const ResetTokenDialog({super.key});
+
+  @override
+  State<ResetTokenDialog> createState() => _ResetTokenDialogState();
+}
+
+class _ResetTokenDialogState extends State<ResetTokenDialog> {
+  @override
+  Widget build(BuildContext context) {
+    return KyberContentDialog(
+      title: const Text('Reset Kyber Auth Token'),
+      content: const Text(
+        'Are you sure you want to reset your authentication token?\n\nThis will log you out of all devices.\n\nIf you are hosting dedicated servers you will need to update the token for them as well.',
+        textAlign: .center,
+      ),
+      constraints: const .new(
+        maxWidth: 600,
+        maxHeight: 400,
+      ),
+      actions: [
+        KyberButton(
+          text: 'Cancel',
+          onPressed: () {
+            Navigator.of(context).pop(false);
+          },
+        ),
+        KyberButton(
+          text: 'Confirm',
+          onPressed: () {
+            Navigator.of(context).pop(true);
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/Launcher/lib/features/settings/screens/pages/accounts_and_updates.dart
+++ b/Launcher/lib/features/settings/screens/pages/accounts_and_updates.dart
@@ -16,6 +16,7 @@ import 'package:kyber_launcher/features/settings/dialogs/change_background_dialo
 import 'package:kyber_launcher/features/settings/dialogs/connect_patreon_dialog.dart';
 import 'package:kyber_launcher/features/settings/dialogs/environment_selector.dart';
 import 'package:kyber_launcher/features/settings/dialogs/release_channel_selector_dialog.dart';
+import 'package:kyber_launcher/features/settings/dialogs/reset_token_dialog.dart';
 import 'package:kyber_launcher/features/settings/dialogs/set_token_dialog.dart';
 import 'package:kyber_launcher/features/settings/dialogs/update_dialog.dart';
 import 'package:kyber_launcher/features/settings/screens/settings.dart';
@@ -59,6 +60,24 @@ class AccountsAndUpdates extends StatelessWidget {
                     value as String;
                     context.read<KyberProxyCubit>().selectProxy(value);
                   },
+                ),
+                KyberTableItem.button(
+                  title: 'Reset Kyber Token',
+                  onClick: () async {
+                    final result = await showKyberDialog<bool?>(
+                      context: context,
+                      builder: (_) => const ResetTokenDialog(),
+                    );
+                    
+                    if (result != true) {
+                      return;
+                    }
+
+                    await sl<KyberGRPCService>().authClient.resetToken(.new());
+
+                    await context.read<MaximaCubit>().requestLogin();
+                  },
+                  text: 'Reset',
                 ),
                 KyberTableItem.button(
                   title: 'NexusMods',

--- a/Launcher/pubspec.yaml
+++ b/Launcher/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   http_cache_hive_store: ^5.0.1
   ffi: ^2.1.3
   file: ^7.0.1
-  file_picker: ^10.0.0
+  file_picker: 10.3.8
   file_selector: ^1.0.0
   fixnum: ^1.1.0
   fluent_ui:

--- a/Module/Proto/kyber_api.proto
+++ b/Module/Proto/kyber_api.proto
@@ -8,6 +8,8 @@ service Authentication {
   rpc Login(LoginRequest) returns (LoginResponse);
   rpc Verify(kyber_common.Empty) returns (VerifyResponse);
 
+  rpc ResetToken(kyber_common.Empty) returns (kyber_common.Empty);
+
   rpc PatreonLogin(AuthCodeRequest) returns (UserVerificationResponse);
   rpc LinkPatreonAccount(LinkPatreonAccountRequest) returns (kyber_common.Empty);
   rpc UnlinkPatreonAccount(kyber_common.Empty) returns (kyber_common.Empty);


### PR DESCRIPTION
- Adds a ResetToken RPC on the API that regenerates the authenticated user token
- Adds a launcher setting with a confirmation dialog to trigger the reset
- After resetting the launcher requests a new login so the new token is used