### PR TITLE
[Module] Override LocalizedStringIdPickerEntity

### DIFF
--- a/Module/Public/Entity/Overrides/LocalizedStringIdPickerEntity.h
+++ b/Module/Public/Entity/Overrides/LocalizedStringIdPickerEntity.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <Entity/NativeEntityManager.h>
+
+#include <Core/DebugHooks.h>
+
+namespace Kyber
+{
+class LocalizedStringIdPickerEntity : public KyberEntity<LocalizedStringIdPickerEntityData>
+{
+public:
+    LocalizedStringIdPickerEntity(EntityManager* entityManager, NativeEntity* entity, LocalizedStringIdPickerEntityData* data);
+
+    void PropertyChanged(PropertyModification* modification) override;
+
+private:
+    PropertyWriter<LocalizedStringId> m_localizedStringId;
+    void GetLocalized();
+};
+} // namespace Kyber

--- a/Module/Public/Entity/Overrides/LocalizedStringIdPickerEntity.h
+++ b/Module/Public/Entity/Overrides/LocalizedStringIdPickerEntity.h
@@ -15,6 +15,7 @@ public:
 
 private:
     PropertyWriter<LocalizedStringId> m_localizedStringId;
+    int32_t CalcStringHash(const std::string&);
     void GetLocalized();
 };
 } // namespace Kyber

--- a/Module/Public/Entity/Overrides/LocalizedStringIdPickerEntity.h
+++ b/Module/Public/Entity/Overrides/LocalizedStringIdPickerEntity.h
@@ -14,8 +14,9 @@ public:
     void PropertyChanged(PropertyModification* modification) override;
 
 private:
-    PropertyWriter<LocalizedStringId> m_localizedStringId;
     int32_t CalcStringHash(const std::string&);
     void GetLocalized();
+
+    PropertyWriter<LocalizedStringId> m_localizedStringId;
 };
 } // namespace Kyber

--- a/Module/Public/SDK/TypeInfo.h
+++ b/Module/Public/SDK/TypeInfo.h
@@ -3055,6 +3055,6 @@ class LocalizedStringIdPickerEntityData : public EntityData
 public:
     Realm Realm; //0x0020
     char* Sid; //0x0028
-};//Size=0x0030
+}; //Size=0x0030
 
 } // namespace Kyber

--- a/Module/Public/SDK/TypeInfo.h
+++ b/Module/Public/SDK/TypeInfo.h
@@ -3049,4 +3049,12 @@ struct QueryEntityResult
     uint32_t Unused;                       // 0x0008
     char _0x000C[4];                       // 0x000C
 };
+
+class LocalizedStringIdPickerEntityData : public EntityData
+{
+public:
+    Realm Realm; //0x0020
+    char* Sid; //0x0028
+};//Size=0x0030
+
 } // namespace Kyber

--- a/Module/Source/Entity/Overrides/LocalizedStringIdPickerEntity.cpp
+++ b/Module/Source/Entity/Overrides/LocalizedStringIdPickerEntity.cpp
@@ -1,0 +1,55 @@
+// Copyright Armchair Developers / Sean Kahler. Licensed under GPLv3.
+
+#include <Entity/Overrides/LocalizedStringIdPickerEntity.h>
+
+#include <Entity/KyberSettings.h>
+#include <Core/Program.h>
+#include <cstdint>
+#include <ios>
+
+namespace Kyber
+{
+KB_IMPLEMENT_ENTITY_OVERRIDE(LocalizedStringIdPickerEntity, LocalizedStringIdPickerEntityData);
+
+LocalizedStringIdPickerEntity::LocalizedStringIdPickerEntity(EntityManager* entityManager, NativeEntity* entity, LocalizedStringIdPickerEntityData* data)
+    : KyberEntity(entity, data)
+{
+    m_localizedStringId = CreateFieldOverride<LocalizedStringId>("StringId", g_program->m_entityManager->GetNativeType("LocalizedStringId"));
+    GetLocalized();
+}
+
+void LocalizedStringIdPickerEntity::PropertyChanged(PropertyModification* modification)
+{
+    GetLocalized();
+}
+
+void LocalizedStringIdPickerEntity::GetLocalized()
+{
+    auto sidField = GetFieldReader<char*>("Sid");
+
+    KYBER_LOG(Debug, "GetLocalized Triggered!");
+
+    std::string id = sidField.HasConnection() && sidField.HasConnectionValue() ? sidField.Get() : GetData()->Sid;
+
+    KYBER_LOG(Debug, "Attempting to hash " << id);
+
+    //hash the id
+    int32_t result = 0xFFFFFFFF; 
+    for (int i = 0; i < id.length(); i++)
+    {
+        result = id[i] + 33 * result;
+    }
+
+    KYBER_LOG(Debug, "Hashed ID " << result);
+    
+    LocalizedStringId* container = g_program->m_entityManager->CreateContainer<LocalizedStringId>("LocalizedStringId");
+    container->StringHash = result;
+
+    KYBER_LOG(Debug, "Created container " << std::hex << container);
+
+    m_localizedStringId = container;
+
+    KYBER_LOG(Debug, "StringId " << m_localizedStringId.Get());
+}
+
+} // namespace Kyber

--- a/Module/Source/Entity/Overrides/LocalizedStringIdPickerEntity.cpp
+++ b/Module/Source/Entity/Overrides/LocalizedStringIdPickerEntity.cpp
@@ -42,5 +42,6 @@ int32_t LocalizedStringIdPickerEntity::CalcStringHash(const std::string& string)
     {
         result = string[i] + 33 * result;
     }
+    return result;
 }
 } // namespace Kyber

--- a/Module/Source/Entity/Overrides/LocalizedStringIdPickerEntity.cpp
+++ b/Module/Source/Entity/Overrides/LocalizedStringIdPickerEntity.cpp
@@ -1,11 +1,9 @@
-// Copyright Armchair Developers / Sean Kahler. Licensed under GPLv3.
+// Copyright Armchair Developers. Licensed under GPLv3.
 
 #include <Entity/Overrides/LocalizedStringIdPickerEntity.h>
 
 #include <Entity/KyberSettings.h>
 #include <Core/Program.h>
-#include <cstdint>
-#include <ios>
 
 namespace Kyber
 {
@@ -23,33 +21,26 @@ void LocalizedStringIdPickerEntity::PropertyChanged(PropertyModification* modifi
     GetLocalized();
 }
 
+// Gets the Sid input to the entity either from a connection or the entity data and creates a LocalizedStringId instance to output to StringId
 void LocalizedStringIdPickerEntity::GetLocalized()
 {
     auto sidField = GetFieldReader<char*>("Sid");
-
-    KYBER_LOG(Debug, "GetLocalized Triggered!");
-
     std::string id = sidField.HasConnection() && sidField.HasConnectionValue() ? sidField.Get() : GetData()->Sid;
+    int32_t stringHash = CalcStringHash(id);
 
-    KYBER_LOG(Debug, "Attempting to hash " << id);
-
-    //hash the id
-    int32_t result = 0xFFFFFFFF; 
-    for (int i = 0; i < id.length(); i++)
-    {
-        result = id[i] + 33 * result;
-    }
-
-    KYBER_LOG(Debug, "Hashed ID " << result);
-    
     LocalizedStringId* container = g_program->m_entityManager->CreateContainer<LocalizedStringId>("LocalizedStringId");
-    container->StringHash = result;
-
-    KYBER_LOG(Debug, "Created container " << std::hex << container);
+    container->StringHash = stringHash;
 
     m_localizedStringId = container;
-
-    KYBER_LOG(Debug, "StringId " << m_localizedStringId.Get());
 }
 
+// Strings in Frostbite are referenced by a hash of a unique ID for each string, This calculates that hash for a given ID and returns it
+int32_t LocalizedStringIdPickerEntity::CalcStringHash(const std::string& string)
+{
+    int32_t result = 0xFFFFFFFF; 
+    for (int i = 0; i < string.length(); i++)
+    {
+        result = string[i] + 33 * result;
+    }
+}
 } // namespace Kyber


### PR DESCRIPTION
- Adds an entity override for LocalizedStringIdPickerEntity, In the base game this entity has an Sid field that cannot be set via a property connection, This override allows for that.

Some things to note:
- The debug logs in here cause issues with the pause screen as it works with ~400 strings every time you go to the main pause menu, I assume this isn't an issue when the log level isn't debug as the logs wouldn't be printed?

- The vanilla entity has a realm field that lets you set the realm of the entity and I didn't do anything for that here. Maybe not a problem? Not sure how to support it either way... Would need help with that 

- ty @MagixGames for all the help with this stuff 
