### PR TITLE
[Module] Internal client refactor

### DIFF
--- a/Module/Public/Core/Client.h
+++ b/Module/Public/Core/Client.h
@@ -1,0 +1,57 @@
+// Copyright Armchair Developers. Licensed under GPLv3.
+
+#pragma once
+
+#include <SDK/SDK.h>
+#include <SDK/TypeInfo.h>
+#include <SDK/Types.h>
+#include <Core/EventManager.h>
+#include <Network/SocketManager.h>
+#include <Voip/VoipManager.h>
+
+#define OFFSET_GET_CLIENT_INSTANCE 0x14659DE50
+
+namespace Kyber
+{
+__int64 ClientStateChangeHk(__int64 a1, ClientState currentClientState, ClientState lastClientState);
+
+class Client : public EventListener
+{
+public:
+    Client();
+    ~Client();
+
+    void Initialize();
+    void InitializeHooks();
+
+    void HandleClientServerJoin(NetworkCreatePlayerMessage* message);
+    void RegisterClientUpdatePassListener(ClientUpdatePassListener* listener);
+    void AttemptJoinVoip();
+
+    // If proxied is true, IP is assumed to be a proxy ID
+    void JoinServer(const std::string& id, std::string ip, uint16_t port, bool spectate, bool proxied = false, bool changeState = true);
+
+    __int64 ChangeClientState(ClientState currentClientState)
+    {
+        return ClientStateChangeHk(
+            *reinterpret_cast<__int64*>(*reinterpret_cast<__int64*>(((__int64 (*)(void))OFFSET_GET_CLIENT_INSTANCE)() + 0x20) + 0x28),
+            currentClientState, m_clientState);
+    }
+
+    void OnEvent(const Event& event) override;
+
+    std::string m_joinToken;
+
+    ClientState m_clientState;
+
+    SocketManager* m_socketManager;
+    VoipManager* m_voipManager;
+    EventManager* m_eventManager;
+
+    std::vector<ClientUpdatePassListener*> m_updatePassListeners;
+
+    bool m_joining;
+    bool m_spectator;
+    bool m_connected;
+};
+} // namespace Kyber

--- a/Module/Public/Core/Program.h
+++ b/Module/Public/Core/Program.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <Core/Server.h>
+#include <Core/Client.h>
 
 #include <SDK/TypeInfo.h>
 #include <SDK/SDK.h>
@@ -14,21 +15,18 @@
 
 #include <Entity/NativeEntityManager.h>
 #include <Script/ScriptManager.h>
-#include <Voip/VoipManager.h>
 
 #include <Windows.h>
 #include <condition_variable>
 
 #define OFFSET_GLOBAL_CLIENT 0x143DCB9D0
 #define OFFSET_GLOBAL_SETTINGS_MANAGER 0x143D11950
-#define OFFSET_GET_CLIENT_INSTANCE 0x14659DE50
 
 namespace Kyber
 {
 TL_DECLARE_FUNC(0x1401F7BD0, DataContainer*, SettingsManager_getSettingsObject, void* inst, const char* identifier);
 TL_DECLARE_FUNC(0x1401F83F0, void, MessageManager_queueMessage, void* pMessageManagerImpl, Message* pMessage, float delayTime);
 
-__int64 ClientStateChangeHk(__int64 a1, ClientState currentClientState, ClientState lastClientState);
 const char* GetHostIdHk(__int64 inst);
 void MessageManagerDispatchMessageHk(void* pMessageManagerImpl, Message* pMessage);
 void OnGotDisconnectedHk(void* inst, SecureReason reason, const eastl::string& reasonText);
@@ -53,14 +51,6 @@ public:
     void InitializeGamePatches();
     void Initialize();
 
-    void RegisterClientUpdatePassListener(ClientUpdatePassListener* listener);
-    void HandleClientServerJoin(NetworkCreatePlayerMessage* message);
-    
-    // If proxied is true, IP is assumed to be a proxy ID
-    void JoinServer(const std::string& id, std::string ip, uint16_t port, bool spectate, bool proxied = false, bool changeState = true);
-
-    void AttemptJoinVoip();
-
     void* GetSettingsManager()
     {
         return *reinterpret_cast<void**>(OFFSET_GLOBAL_SETTINGS_MANAGER);
@@ -70,13 +60,6 @@ public:
     T* GetSettingsObject(const char* identifier)
     {
         return reinterpret_cast<T*>(SettingsManager_getSettingsObject(GetSettingsManager(), identifier));
-    }
-
-    __int64 ChangeClientState(ClientState currentClientState)
-    {
-        return ClientStateChangeHk(
-            *reinterpret_cast<__int64*>(*reinterpret_cast<__int64*>(((__int64 (*)(void))OFFSET_GET_CLIENT_INSTANCE)() + 0x20) + 0x28),
-            currentClientState, m_clientState);
     }
 
     API* GetAPI()
@@ -90,30 +73,20 @@ public:
     ModData m_modData;
 
     Server* m_server;
+    Client* m_client;
     Console* m_console;
 
     EntityManager* m_entityManager;
     ScriptManager* m_scriptManager;
 
     KyberSettingsManager* m_settingsManager;
-    VoipManager* m_voipManager;
-
-    SocketManager* m_clientSocketManager;
-
-    ClientState m_clientState;
 
     std::vector<std::function<void()>> m_consoleRegistrationCallbacks;
-    std::vector<ClientUpdatePassListener*> m_clientUpdatePassListeners;
 
     std::mutex m_startupMutex;
     std::condition_variable m_startupCondition;
 
-    std::string m_joinToken;
-
     bool m_startupInitialized;
-    bool m_joining;
-    bool m_spectator;
-    bool m_connected;
     bool m_allowInteraction;
     bool m_isDedicatedServer;
     bool m_messageDebugEnabled;

--- a/Module/Public/Core/Program.h
+++ b/Module/Public/Core/Program.h
@@ -24,6 +24,8 @@
 
 namespace Kyber
 {
+extern void* s_mainLoop;
+
 TL_DECLARE_FUNC(0x1401F7BD0, DataContainer*, SettingsManager_getSettingsObject, void* inst, const char* identifier);
 TL_DECLARE_FUNC(0x1401F83F0, void, MessageManager_queueMessage, void* pMessageManagerImpl, Message* pMessage, float delayTime);
 

--- a/Module/Public/Core/Server.h
+++ b/Module/Public/Core/Server.h
@@ -18,8 +18,6 @@
 
 namespace Kyber
 {
-extern void* s_mainLoop;
-
 void InitLevelSetup(LevelSetup* levelSetup, const char* level, const char* mode, const char* startPoint, const char* initialSubLevel);
 
 struct ServerCreationInfo

--- a/Module/Public/Core/Server.h
+++ b/Module/Public/Core/Server.h
@@ -20,6 +20,8 @@ namespace Kyber
 {
 extern void* s_mainLoop;
 
+void InitLevelSetup(LevelSetup* levelSetup, const char* level, const char* mode, const char* startPoint, const char* initialSubLevel);
+
 struct ServerCreationInfo
 {
     std::string name;
@@ -106,13 +108,11 @@ public:
 
     void SetDedicatedCreationInfo(const ServerCreationInfo& info);
 
-    // The events in this manager are processed once on MainLoop::init
-    EventManager* m_mainLoopInitEventManager;
-
     SocketManager* m_socketManager;
     ISocket* m_natClient;
     ServerPlayerManager* m_playerManager;
     PersistenceManager* m_persistenceManager;
+    EventManager* m_eventManager;
     SocketSpawnInfo m_socketSpawnInfo;
     MapRotation m_mapRotation;
     std::string m_currentLevel;

--- a/Module/Public/SDK/Funcs.h
+++ b/Module/Public/SDK/Funcs.h
@@ -11,7 +11,6 @@ namespace Kyber
 {
 // ClientServer
 TL_DECLARE_FUNC(0x140BCF350, void, ServerLoadLevelMessage_post, LevelSetup* levelSetup, bool fadeOut, bool forceReloadResources);
-TL_DECLARE_FUNC(0x14131AB20, void*, DirtySockSocketManager_ctor, void* inst, MemoryArena* arena, uint32_t maxPacketSize);
 TL_DECLARE_FUNC(0x14193DA20, bool, Server_sendChatMessage, ChatChannel channel, const char* message, const ServerPlayer* player);
 TL_DECLARE_FUNC(0x140C162F0, void, Server_setCompleted);
 

--- a/Module/Source/Core/Client.cpp
+++ b/Module/Source/Core/Client.cpp
@@ -1,0 +1,439 @@
+// Copyright Armchair Developers / Sean Kahler. Licensed under GPLv3.
+
+#include <Core/Client.h>
+
+#include <Core/Program.h>
+#include <Hook/HookManager.h>
+#include <Base/Log.h>
+#include <Utilities/MemoryUtils.h>
+#include <SDK/TypeInfo.h>
+#include <SDK/SDK.h>
+#include <SDK/Funcs.h>
+
+#include <optional>
+
+namespace Kyber
+{
+
+Client::Client()
+    : m_joining(false)
+    , m_spectator(false)
+    , m_connected(false)
+    , m_voipManager(nullptr)
+    , m_socketManager(nullptr)
+    , m_eventManager(new EventManager())
+    , m_clientState(ClientState_None)
+{
+    m_eventManager->RegisterListener<MainLoopInitJoinServerEvent>(this);
+}
+
+Client::~Client()
+{
+    KYBER_LOG(Debug, "[Client] Destroying");
+}
+
+void Client::HandleClientServerJoin(NetworkCreatePlayerMessage* message)
+{
+    if (!m_joining && !m_connected && !g_program->m_server->m_runningHosted)
+    {
+        return;
+    }
+
+    if (!g_program->m_server->m_onlineMode)
+    {
+        return;
+    }
+
+    char* name = StringUtils::CopyWithArena("KyberAuthentication:" + m_joinToken);
+    message->playerName = name;
+    message->isSpectator = m_spectator;
+
+    KYBER_LOG(Info, "[Client] Joining game with authentication");
+    KYBER_LOG(Debug, "[Client] Joining game as '" << message->playerName << "'");
+
+    AttemptJoinVoip();
+}
+
+void Client::AttemptJoinVoip()
+{
+    if (m_voipManager == nullptr || !m_voipManager->IsLoggedIn() ||
+        g_program->m_server->m_socketSpawnInfo.serverName.empty() || m_voipManager->IsConnected())
+    {
+        return;
+    }
+
+    KYBER_LOG(Info, "[Client] Joining VoIP");
+    g_program->GetAPI()->GetVoip()->JoinChannel(
+        g_program->m_server->m_socketSpawnInfo.serverName, [&](std::optional<const VoipJoinChannelResponse*> response) {
+            if (!response)
+            {
+                KYBER_LOG(Error, "[VoIP] Failed to retrieve vivox channel credentials. Proximity chat will not work!");
+                return;
+            }
+
+            m_voipManager->AddSession((*response)->channel(), (*response)->accesstoken());
+        });
+}
+
+void Client::JoinServer(const std::string& id, std::string ip, uint16_t port, bool spectate, bool proxied, bool changeState)
+{
+    if (!id.empty())
+    {
+        auto server = g_program->GetAPI()->GetServerBrowser()->GetServer(id);
+        if (!server)
+        {
+            KYBER_LOG(Error, "[Client] Server " << id << " not found, connection failed!");
+            return;
+        }
+
+        auto meta = server->meta();
+        auto proxy_id_it = meta.find("pinned_proxy_id");
+        if (proxy_id_it != meta.end())
+        {
+            auto proxies = g_program->GetAPI()->GetProxy()->GetList();
+            for (const auto& proxy : proxies)
+            {
+                if (proxy.id() == proxy_id_it->second)
+                {
+                    ip = proxy.ip();
+                    KYBER_LOG(Info, "[Client] Overriding with pinned proxy '" << proxy.id() << "'");
+                    break;
+                }
+            }
+        }
+    }
+
+    ClientSettings* clientSettings = Settings<ClientSettings>("Client");
+    clientSettings->ServerIp = StringUtils::CopyWithArena(ip);
+
+    SocketSpawnInfo info(proxied, proxied ? ip : "", id, "");
+    g_program->m_server->m_socketSpawnInfo = info;
+    m_joining = true;
+    m_spectator = spectate;
+
+    KYBER_LOG(Info, "[Client] Joining server " << id << " at " << ip << ":" << port << " [Proxied: " << proxied
+                                               << ", Spectate: " << spectate << ", ChangeState: " << changeState << "]");
+
+    Settings<NetworkSettings>("Network")->ServerPort = port;
+    if (changeState)
+    {
+        ChangeClientState(ClientState_Startup);
+    }
+}
+
+__int64 ClientCtorHk(__int64 inst, void* a2, __int64 a3)
+{
+    static const auto trampoline = HookManager::Call(ClientCtorHk);
+    KYBER_LOG(Info, "[Client] Creating client");
+
+    if (g_program->m_client->m_voipManager != nullptr)
+    {
+        g_program->m_client->m_voipManager->Init();
+    }
+
+    if (g_program->m_scriptManager != nullptr)
+    {
+        g_program->m_scriptManager->LoadScripts(PluginRealm_Client);
+    }
+
+    return trampoline(inst, a2, a3);
+}
+
+__int64 ClientStateChangeHk(__int64 inst, ClientState currentClientState, ClientState lastClientState)
+{
+    static const auto trampoline = HookManager::Call(ClientStateChangeHk);
+    g_program->m_client->m_clientState = currentClientState;
+    KYBER_LOG(Info, "[Client] Client state changed to " << ClientStateToString(currentClientState));
+    Server* server = g_program->m_server;
+    if (!server)
+    {
+        return trampoline(inst, currentClientState, lastClientState);
+    }
+
+    if (currentClientState == ClientState_Startup)
+    {
+        static bool firstStartup = true;
+
+        // g_program->m_console->UnregisterCommands();
+        g_program->m_allowInteraction = false;
+
+        if ((server->m_runningHosted || g_program->m_client->m_connected) && g_program->m_client->m_socketManager)
+        {
+            // g_program->m_clientSocketManager->CloseSockets();
+            g_program->m_client->m_socketManager = nullptr;
+        }
+
+        if (g_program->m_client->m_connected)
+        {
+            KYBER_LOG(Info, "[Client] Leaving server");
+
+            if (g_program->m_client->m_voipManager != nullptr)
+            {
+                g_program->m_client->m_voipManager->RemoveSession();
+            }
+
+            g_program->m_client->m_spectator = false;
+        }
+
+        g_program->m_client->m_connected = false;
+
+        if (server->m_runningHosted)
+        {
+            if (!server->m_restarting)
+            {
+                KYBER_LOG(Info, "[Server] Stopping server");
+                server->Stop();
+
+                if (g_program->m_client->m_voipManager != nullptr)
+                {
+                    g_program->m_client->m_voipManager->RemoveSession();
+                }
+
+                g_program->m_client->m_spectator = false;
+
+                GameSettings* gameSettings = Settings<GameSettings>("Game");
+                gameSettings->Level = const_cast<char*>(StringUtils::CopyWithArena("Levels/FrontEnd/FrontEnd"));
+                gameSettings->DefaultLayerInclusion = const_cast<char*>(StringUtils::CopyWithArena(""));
+            }
+            else
+            {
+                server->m_restarting = false;
+            }
+        }
+        else if (!g_program->m_client->m_joining && !firstStartup)
+        {
+            Settings<ClientSettings>("Client")->ServerIp = const_cast<char*>(StringUtils::CopyWithArena(""));
+        }
+
+        server->OnClientStartup();
+
+        firstStartup = false;
+    }
+    else if (currentClientState == ClientState_Ingame)
+    {
+        g_program->GetAPI()->GetLauncherInterface()->OnServerJoined();
+        g_program->m_allowInteraction = true;
+        if (server->m_runningHosted)
+        {
+            server->InitializeGameSettings();
+        }
+    }
+
+    return trampoline(inst, currentClientState, lastClientState);
+}
+
+// TODO: Properly implement the EngineConnection type to not have this garbage
+class EngineConnection2
+{
+public:
+    char pad_0000[1544];   // 0x0000
+    char* m_reasonText;    // 0x0608
+    char pad_0610[24];     // 0x0610
+    SecureReason m_reason; // 0x0628
+};
+
+void ClientConnectionOnDisconnectedHk(__int64 inst)
+{
+    static const auto trampoline = HookManager::Call(ClientConnectionOnDisconnectedHk);
+
+    EngineConnection2* connBase = (EngineConnection2*)(inst - 0x10); // ClientConnection -> EngineConnection
+    SecureReason reason = connBase->m_reason;
+    char* reasonText = connBase->m_reasonText;
+
+    if (reason == SecureReason_TimedOut)
+    {
+        reason = SecureReason_KickedViaFairFight;
+        reasonText = StringUtils::CopyWithArena("Timed out.", FB_CLIENT_ARENA);
+    }
+    else if (reason == SecureReason_NoReply)
+    {
+        reason = SecureReason_KickedViaFairFight;
+        reasonText = StringUtils::CopyWithArena("The server did not reply.", FB_CLIENT_ARENA);
+    }
+    else if (reason == SecureReason_KickedByAdmin)
+    {
+        reason = SecureReason_KickedViaFairFight;
+        reasonText =
+            StringUtils::CopyWithArena("You were kicked by a server admin.\n\nReason: " + std::string(reasonText), FB_CLIENT_ARENA);
+    }
+
+    KYBER_LOG(Info, "[Client] Disconnected from server: " << std::hex << reason << " " << reasonText);
+
+    g_program->GetAPI()->GetLauncherInterface()->OnServerDisconnect();
+
+    connBase->m_reason = reason;
+    connBase->m_reasonText = reasonText;
+    trampoline(inst);
+}
+
+void ClientConnectionSendMessageHk(void* inst, Message* message)
+{
+    static const auto trampoline = HookManager::Call(ClientConnectionSendMessageHk);
+    if (message != nullptr && message->Is("NetworkCreatePlayerMessage"))
+    {
+        NetworkCreatePlayerMessage* msg = static_cast<NetworkCreatePlayerMessage*>(message);
+        g_program->m_client->HandleClientServerJoin(msg);
+    }
+    trampoline(inst, message);
+}
+
+bool ClientInitNetworkHk(__int64 inst, bool singleplayer, bool localhost, bool coop, bool hosted)
+{
+    static const auto trampoline = HookManager::Call(ClientInitNetworkHk);
+    KYBER_LOG(Info, "[Client] Client is initializing network, singleplayer: " << singleplayer);
+    if (g_program->m_server->m_runningHosted || strlen(Settings<ClientSettings>("Client")->ServerIp) > 0)
+    {
+        *reinterpret_cast<void**>(inst + 0xA8) =
+            reinterpret_cast<void*>(new SocketManagerCreator(&g_program->m_client->m_socketManager, g_program->m_server->m_socketSpawnInfo));
+        KYBER_LOG(Info, "[Client] Using custom socket manager");
+    }
+    return trampoline(inst, singleplayer, localhost, coop, hosted);
+}
+
+void ClientConnectToAddressHk(__int64 inst, const char* ipAddress, const char* serverPassword)
+{
+    static const auto trampoline = HookManager::Call(ClientConnectToAddressHk);
+    SocketSpawnInfo info = g_program->m_server->m_socketSpawnInfo;
+    if (false && g_program->m_client->m_joining && info.isProxied)
+    {
+        KYBER_LOG(Info, "[Client] Connecting to server (proxied)");
+        trampoline(inst, (std::string(info.proxyAddress) + ":25201").c_str(), serverPassword);
+    }
+    else
+    {
+        KYBER_LOG(Info, "[Client] Connecting to server " << ipAddress);
+        trampoline(inst, ipAddress, serverPassword);
+    }
+
+    if (g_program->m_client->m_joining)
+    {
+        g_program->m_client->m_connected = true;
+        g_program->m_client->m_joining = false;
+    }
+}
+
+void** OnlineManagerConnectHk(void* inst, const SocketAddr& address)
+{
+    static const auto trampoline = HookManager::Call(OnlineManagerConnectHk);
+
+    StringBuilder builder;
+    char buf[256];
+
+    StringBuilder_ctor(&builder, buf, 256);
+    networkAddressToString(&address, builder);
+
+    KYBER_LOG(Info, "[Client] Connecting to server (2) " << buf);
+
+    // std::ofstream fout;
+    // fout.open("addr.bin", std::ios::binary | std::ios::out);
+
+    // fout.write((char*)&address, sizeof(SocketAddr));
+    // fout.close();
+
+    return trampoline(inst, address);
+}
+
+__int64 ClientUpdatePassPreFrameHk(void* inst, const UpdateParameters& params)
+{
+    static const auto trampoline = HookManager::Call(ClientUpdatePassPreFrameHk);
+    __int64 result = trampoline(inst, params);
+
+    if (g_program->m_entityManager != nullptr)
+    {
+        g_program->m_entityManager->UpdateEntities(Realm_Client, params);
+    }
+
+    for (const auto& listener : g_program->m_client->m_updatePassListeners)
+    {
+        listener->Call(ClientUpdatePass_PreFrame);
+    }
+
+    g_threadExecutor->Process(GameThread_Client);
+
+    if (!g_program->m_server->IsRunning())
+    {
+        g_program->GetAPI()->Update();
+    }
+
+    if (g_program->m_scriptManager != nullptr)
+    {
+        g_program->m_scriptManager->GetEventManager().Fire("Client:UpdatePre", params.simulationDeltaTime.toSecondsAsFloat());
+    }
+
+    GenericUpdateManager::Get().Call(UpdateType_Client_PreFrame, params);
+    return result;
+}
+
+__int64 ClientUpdatePassPostFrameHk(void* inst, const UpdateParameters& params)
+{
+    static const auto trampoline = HookManager::Call(ClientUpdatePassPostFrameHk);
+    __int64 result = trampoline(inst, params);
+
+    for (const auto& listener : g_program->m_client->m_updatePassListeners)
+    {
+        listener->Call(ClientUpdatePass_PostFrame);
+    }
+
+    if (g_program->m_scriptManager != nullptr)
+    {
+        g_program->m_scriptManager->GetEventManager().Fire("Client:UpdatePost", params.simulationDeltaTime.toSecondsAsFloat());
+    }
+
+    GenericUpdateManager::Get().Call(UpdateType_Client_PostFrame, params);
+    return result;
+}
+
+__int64 ClientAuthHk(__int64 a1, OnlineId* a2, unsigned int a3)
+{
+    static const auto trampoline = HookManager::Call(ClientAuthHk);
+    __int64 result = trampoline(a1, a2, a3);
+    KYBER_LOG(Info, "[Client] Joining server authenticated as " << a2->m_nativeData << " " << a2->m_id << " " << a3);
+    return result;
+}
+
+void Client::OnEvent(const Event& event)
+{
+    if (event.is<MainLoopInitJoinServerEvent>())
+    {
+        const auto& e = event.as<MainLoopInitJoinServerEvent>();
+        JoinServer(e.id, e.ip, e.port, e.spectate, e.proxied, false);
+    }
+}
+
+void Client::RegisterClientUpdatePassListener(ClientUpdatePassListener* listener)
+{
+    m_updatePassListeners.push_back(listener);
+}
+
+void Client::Initialize()
+{
+    InitializeHooks();
+}
+
+void Client::InitializeHooks()
+{
+    // clang-format off
+    HookTemplate hookOffsets[] = {
+        { HOOK_OFFSET(0x140A8C7A0), ClientStateChangeHk },
+        { HOOK_OFFSET(0x140CB7800), ClientConnectionOnDisconnectedHk },
+        { HOOK_OFFSET(0x140CBA480), ClientConnectionSendMessageHk },
+        { HOOK_OFFSET(0x140A874C0), ClientCtorHk },
+        { HOOK_OFFSET(0x1465D9FA0), ClientUpdatePassPreFrameHk },
+        { HOOK_OFFSET(0x1465D9C30), ClientUpdatePassPostFrameHk },
+        { HOOK_OFFSET(0x1418D92B0), ClientAuthHk },
+        { HOOK_OFFSET(0x140A8DE80), ClientInitNetworkHk },
+        { HOOK_OFFSET(0x140CB3990), ClientConnectToAddressHk },
+        { HOOK_OFFSET(0x140CB3640), OnlineManagerConnectHk },
+    };
+    // clang-format on
+
+    for (HookTemplate& hook : hookOffsets)
+    {
+        HookManager::CreateHook(hook.offset, hook.hook);
+    }
+
+    Hook::ApplyQueuedActions();
+    KYBER_LOG(Debug, "[Client] Initialized Client Hooks");
+}
+
+} // namespace Kyber

--- a/Module/Source/Core/Client.cpp
+++ b/Module/Source/Core/Client.cpp
@@ -349,6 +349,7 @@ __int64 ClientUpdatePassPreFrameHk(void* inst, const UpdateParameters& params)
     }
 
     g_threadExecutor->Process(GameThread_Client);
+    g_program->m_client->m_eventManager->ProcessEventQueue();
 
     if (!g_program->m_server->IsRunning())
     {

--- a/Module/Source/Core/Console.cpp
+++ b/Module/Source/Core/Console.cpp
@@ -528,7 +528,7 @@ void JoinServerCommand(ConsoleContext& cc)
     stream >> ip >> port;
 
     cc << "Connecting to " << ip << ":" << port << "...";
-    g_program->JoinServer("", ip, port, "", false);
+    g_program->m_client->JoinServer("", ip, port, "", false);
 }
 
 void FullEntityBusInternalFireEventHk2(void* inst, const DataContainer* data, const EntityEvent* entityEvent)

--- a/Module/Source/Core/Program.cpp
+++ b/Module/Source/Core/Program.cpp
@@ -33,14 +33,11 @@
 #include <memory>
 #include <mutex>
 
-#define OFFSET_CLIENT_CTOR HOOK_OFFSET(0x140A874C0)
-#define OFFSET_CLIENT_STATE_CHANGE HOOK_OFFSET(0x140A8C7A0)
 #define OFFSET_GET_SETTINGS_OBJECT HOOK_OFFSET(0x1401F7BD0)
 #define OFFSET_ENVIRONMENT_GET_HOST_ID HOOK_OFFSET(0x1454D5900)
 #define OFFSET_ENVIRONMENT_GET_HOST_IDENTIFIER HOOK_OFFSET(0x1454D59E0)
 #define OFFSET_MESSAGEMANAGER_QUEUE_MESSAGE HOOK_OFFSET(0x1401F8950)
 #define OFFSET_MESSAGEMANAGER_DISPATCH_MESSAGE HOOK_OFFSET(0x1401F6CA0)
-#define OFFSET_CLIENTCONNECTION_ONDISCONNECTED HOOK_OFFSET(0x140CB7800)
 #define OFFSET_STREAMMANAGERMOVECLIENT_TRANSMIT HOOK_OFFSET(0x140D538E0)
 #define OFFSET_STREAMMANAGERMOVESERVER_RECEIVE HOOK_OFFSET(0x140D51E40)
 #define OFFSET_STREAMMANAGERCHAT_TRANSMIT HOOK_OFFSET(0x1419411C0)
@@ -50,36 +47,32 @@
 #define OFFSET_MEMORYARENA_ALLOC HOOK_OFFSET(0x14541CD00)
 #define OFFSET_MEMORYARENA_LOG HOOK_OFFSET(0x14019AAA0)
 #define OFFSET_READOBFUSCATED HOOK_OFFSET(0x1454DC150)
-#define OFFSET_CLIENTCONNECTION_SENDMESSAGE HOOK_OFFSET(0x140CBA480)
 #define OFFSET_GETLOCALIZEDSTRING HOOK_OFFSET(0x147792030)
 #define OFFSET_FILESUPERBUNDLEMANAGER_UPDATECONFIG HOOK_OFFSET(0x14024CA10)
-#define OFFSET_CLIENT_UPDATEPASSPREFRAME HOOK_OFFSET(0x1465D9FA0)
-#define OFFSET_CLIENT_UPDATEPASSPOSTFRAME HOOK_OFFSET(0x1465D9C30)
 #define OFFSET_KICK_DISCONNECTED_PLAYERS HOOK_OFFSET(0x140D5F330)
+#define OFFSET_MAINLOOP_INIT HOOK_OFFSET(0x140186B90)
+#define OFFSET_MAINLOOP_INITDATAPLATFORM HOOK_OFFSET(0x145315E30)
+#define OFFSET_GAMESIMULATION_INIT HOOK_OFFSET(0x145315930)
+#define OFFSET_GAMESIMULATION_SPAWNSERVER HOOK_OFFSET(0x14018EE70)
 
 using namespace fastdelegate;
 
 namespace Kyber
 {
+TL_DECLARE_FUNC(0x14131AB20, void*, DirtySockSocketManager_ctor, void* inst, MemoryArena* arena, uint32_t maxPacketSize);
+
 Program* g_program;
 
 Program::Program(HMODULE module)
     : m_module(module)
     , m_api(nullptr)
+    , m_client(nullptr)
     , m_server(nullptr)
     , m_console(nullptr)
     , m_entityManager(nullptr)
     , m_scriptManager(nullptr)
-    , m_settingsManager(nullptr)
-    //, m_frostyLink(nullptr)
-    //, m_replaySystem(nullptr)
-    , m_voipManager(nullptr)
-    , m_clientSocketManager(nullptr)
-    , m_clientState(ClientState_None)
+    , m_settingsManager(nullptr) 
     , m_startupInitialized(false)
-    , m_joining(false)
-    , m_spectator(false)
-    , m_connected(false)
     , m_allowInteraction(true)
     , m_isDedicatedServer(false)
     , m_messageDebugEnabled(false)
@@ -228,13 +221,14 @@ void Program::InitializationThread()
     m_interface = std::make_unique<InterfaceService>();
 
     m_server = new Server();
+    m_client = new Client();
     m_entityManager = new EntityManager();
     m_settingsManager = new KyberSettingsManager();
     m_scriptManager = new ScriptManager();
 
     if (!m_isDedicatedServer)
     {
-        m_voipManager = new VoipManager();
+        m_client->m_voipManager = new VoipManager();
     }
 
     std::string title = "KYBER";
@@ -312,93 +306,6 @@ void Program::InitializeConsole()
     m_consoleRegistrationCallbacks.clear();
 }
 
-void Program::HandleClientServerJoin(NetworkCreatePlayerMessage* message)
-{
-    if (!m_joining && !m_connected && !m_server->m_runningHosted)
-    {
-        return;
-    }
-
-    if (!m_server->m_onlineMode)
-    {
-        return;
-    }
-
-    char* name = StringUtils::CopyWithArena("KyberAuthentication:" + m_joinToken);
-    message->playerName = name;
-    message->isSpectator = m_spectator;
-
-    KYBER_LOG(Info, "[Client] Joining game with authentication");
-    KYBER_LOG(Debug, "[Client] Joining game as '" << message->playerName << "'");
-
-    AttemptJoinVoip();
-}
-
-void Program::AttemptJoinVoip()
-{
-    if (m_voipManager == nullptr || !m_voipManager->IsLoggedIn() || m_server->m_socketSpawnInfo.serverName.empty() || m_voipManager->IsConnected())
-    {
-        return;
-    }
-
-    KYBER_LOG(Info, "[Client] Joining VoIP");
-    m_api->GetVoip()->JoinChannel(m_server->m_socketSpawnInfo.serverName, [&](std::optional<const VoipJoinChannelResponse*> response) {
-        if (!response)
-        {
-            KYBER_LOG(Error, "[VoIP] Failed to retrieve vivox channel credentials. Proximity chat will not work!");
-            return;
-        }
-
-        m_voipManager->AddSession((*response)->channel(), (*response)->accesstoken());
-    });
-}
-
-void Program::JoinServer(const std::string& id, std::string ip, uint16_t port, bool spectate, bool proxied, bool changeState)
-{
-    if (!id.empty())
-    {
-        auto server = m_api->GetServerBrowser()->GetServer(id);
-        if (!server)
-        {
-            KYBER_LOG(Error, "[Client] Server " << id << " not found, connection failed!");
-            return;
-        }
-
-        auto meta = server->meta();
-        auto proxy_id_it = meta.find("pinned_proxy_id");
-        if (proxy_id_it != meta.end())
-        {
-            auto proxies = g_program->GetAPI()->GetProxy()->GetList();
-            for (const auto& proxy : proxies)
-            {
-                if (proxy.id() == proxy_id_it->second)
-                {
-                    ip = proxy.ip();
-                    KYBER_LOG(Info, "[Client] Overriding with pinned proxy '" << proxy.id() << "'");
-                    break;
-                }
-            }
-        }
-    }
-
-    ClientSettings* clientSettings = Settings<ClientSettings>("Client");
-    clientSettings->ServerIp = StringUtils::CopyWithArena(ip);
-
-    SocketSpawnInfo info(proxied, proxied ? ip : "", id, "");
-    m_server->m_socketSpawnInfo = info;
-    m_joining = true;
-    m_spectator = spectate;
-
-    KYBER_LOG(Info, "[Client] Joining server " << id << " at " << ip << ":" << port << " [Proxied: " << proxied
-                                               << ", Spectate: " << spectate << ", ChangeState: " << changeState << "]");
-
-    Settings<NetworkSettings>("Network")->ServerPort = port;
-    if (changeState)
-    {
-        ChangeClientState(ClientState_Startup);
-    }
-}
-
 void MemoryArenaLog(__int64 a1, const char* format, ...)
 {
     static const auto trampoline = HookManager::Call(MemoryArenaLog);
@@ -419,107 +326,6 @@ uint8_t* ReadObfuscatedHk(uint8_t* data, uint32_t* size)
     return data + 0x22C;
 }
 
-__int64 ClientCtorHk(__int64 inst, void* a2, __int64 a3)
-{
-    static const auto trampoline = HookManager::Call(ClientCtorHk);
-    KYBER_LOG(Info, "[Client] Creating client");
-
-    if (g_program->m_voipManager != nullptr)
-    {
-        g_program->m_voipManager->Init();
-    }
-
-    if (g_program->m_scriptManager != nullptr)
-    {
-        g_program->m_scriptManager->LoadScripts(PluginRealm_Client);
-    }
-
-    return trampoline(inst, a2, a3);
-}
-
-__int64 ClientStateChangeHk(__int64 inst, ClientState currentClientState, ClientState lastClientState)
-{
-    static const auto trampoline = HookManager::Call(ClientStateChangeHk);
-    g_program->m_clientState = currentClientState;
-    KYBER_LOG(Info, "[Client] Client state changed to " << ClientStateToString(currentClientState));
-    Server* server = g_program->m_server;
-    if (!server)
-    {
-        return trampoline(inst, currentClientState, lastClientState);
-    }
-
-    if (currentClientState == ClientState_Startup)
-    {
-        static bool firstStartup = true;
-
-        // g_program->m_console->UnregisterCommands();
-        g_program->m_allowInteraction = false;
-
-        if ((server->m_runningHosted || g_program->m_connected) && g_program->m_clientSocketManager)
-        {
-            // g_program->m_clientSocketManager->CloseSockets();
-            g_program->m_clientSocketManager = nullptr;
-        }
-
-        if (g_program->m_connected)
-        {
-            KYBER_LOG(Info, "[Client] Leaving server");
-
-            if (g_program->m_voipManager != nullptr)
-            {
-                g_program->m_voipManager->RemoveSession();
-            }
-
-            g_program->m_spectator = false;
-        }
-
-        g_program->m_connected = false;
-
-        if (server->m_runningHosted)
-        {
-            if (!server->m_restarting)
-            {
-                KYBER_LOG(Info, "[Server] Stopping server");
-                server->Stop();
-
-                if (g_program->m_voipManager != nullptr)
-                {
-                    g_program->m_voipManager->RemoveSession();
-                }
-
-                g_program->m_spectator = false;
-
-                GameSettings* gameSettings = Settings<GameSettings>("Game");
-                gameSettings->Level = const_cast<char*>(StringUtils::CopyWithArena("Levels/FrontEnd/FrontEnd"));
-                gameSettings->DefaultLayerInclusion = const_cast<char*>(StringUtils::CopyWithArena(""));
-            }
-            else
-            {
-                server->m_restarting = false;
-            }
-        }
-        else if (!g_program->m_joining && !firstStartup)
-        {
-            Settings<ClientSettings>("Client")->ServerIp = const_cast<char*>(StringUtils::CopyWithArena(""));
-        }
-
-        server->OnClientStartup();
-
-        firstStartup = false;
-    }
-    else if (currentClientState == ClientState_Ingame)
-    {
-        g_program->GetAPI()->GetLauncherInterface()->OnServerJoined();
-        g_program->m_allowInteraction = true;
-        if (server->m_runningHosted)
-        {
-            server->InitializeGameSettings();
-        }
-    }
-
-    return trampoline(inst, currentClientState, lastClientState);
-}
-
 __int64 OriginSDKInitializeHk(void* inst, int a2, uint16_t lsxPort, void* a4, void* a5)
 {
     static const auto trampoline = HookManager::Call(OriginSDKInitializeHk);
@@ -531,61 +337,6 @@ __int64 OriginSDKInitializeHk(void* inst, int a2, uint16_t lsxPort, void* a4, vo
     }
 
     return trampoline(inst, a2, lsxPort, a4, a5);
-}
-
-// TODO: Properly implement the EngineConnection type to not have this garbage
-class EngineConnection2
-{
-public:
-    char pad_0000[1544];   // 0x0000
-    char* m_reasonText;    // 0x0608
-    char pad_0610[24];     // 0x0610
-    SecureReason m_reason; // 0x0628
-};
-
-void ClientConnectionOnDisconnectedHk(__int64 inst)
-{
-    static const auto trampoline = HookManager::Call(ClientConnectionOnDisconnectedHk);
-
-    EngineConnection2* connBase = (EngineConnection2*)(inst - 0x10); // ClientConnection -> EngineConnection
-    SecureReason reason = connBase->m_reason;
-    char* reasonText = connBase->m_reasonText;
-
-    if (reason == SecureReason_TimedOut)
-    {
-        reason = SecureReason_KickedViaFairFight;
-        reasonText = StringUtils::CopyWithArena("Timed out.", FB_CLIENT_ARENA);
-    }
-    else if (reason == SecureReason_NoReply)
-    {
-        reason = SecureReason_KickedViaFairFight;
-        reasonText = StringUtils::CopyWithArena("The server did not reply.", FB_CLIENT_ARENA);
-    }
-    else if (reason == SecureReason_KickedByAdmin)
-    {
-        reason = SecureReason_KickedViaFairFight;
-        reasonText =
-            StringUtils::CopyWithArena("You were kicked by a server admin.\n\nReason: " + std::string(reasonText), FB_CLIENT_ARENA);
-    }
-
-    KYBER_LOG(Info, "[Client] Disconnected from server: " << std::hex << reason << " " << reasonText);
-
-    g_program->GetAPI()->GetLauncherInterface()->OnServerDisconnect();
-
-    connBase->m_reason = reason;
-    connBase->m_reasonText = reasonText;
-    trampoline(inst);
-}
-
-void ClientConnectionSendMessageHk(void* inst, Message* message)
-{
-    static const auto trampoline = HookManager::Call(ClientConnectionSendMessageHk);
-    if (message != nullptr && message->Is("NetworkCreatePlayerMessage"))
-    {
-        NetworkCreatePlayerMessage* msg = static_cast<NetworkCreatePlayerMessage*>(message);
-        g_program->HandleClientServerJoin(msg);
-    }
-    trampoline(inst, message);
 }
 
 TL_DECLARE_FUNC(0x146C5EF40, __int64, __unkServerGhosts, __int64*);
@@ -731,6 +482,157 @@ void MessageManagerDispatchMessageHk(void* inst, Message* message)
     trampoline(inst, message);
 }
 
+struct MainLoop
+{
+    char pad_0000[8];       // 0x0000
+    bool isDedicatedServer; // 0x0008
+};
+
+void* s_mainLoop = nullptr;
+
+bool MainLoopInitHk(MainLoop* inst)
+{
+    static const auto trampoline = HookManager::Call(MainLoopInitHk);
+    s_mainLoop = inst;
+
+    if (g_program->m_isDedicatedServer)
+    {
+        inst->isDedicatedServer = true;
+    }
+
+    g_program->InitializeConsole();
+
+    if (g_program->m_scriptManager != nullptr)
+    {
+        g_program->m_scriptManager->LoadScripts(PluginRealm_Server);
+    }
+
+    KYBER_LOG(Info, "[Engine] Initializing Game Loop");
+    bool result = trampoline(inst);
+
+    KYBER_LOG(Info, "[Engine] Processing initial events");
+    g_program->m_server->m_eventManager->ProcessEventQueue();
+    g_program->m_client->m_eventManager->ProcessEventQueue();
+
+    if (g_program->m_settingsManager != nullptr)
+    {
+        g_program->m_settingsManager->ApplySettings();
+        g_program->m_server->OnSettingsRegistered();
+    }
+
+    return result;
+}
+
+void MainLoopInitDataPlatform()
+{
+    static const auto trampoline = HookManager::Call(MainLoopInitDataPlatform);
+    trampoline();
+
+    /*const char** dataPlatformPathName = (const char**)0x143AF6010;
+    *dataPlatformPathName = "DedicatedServer";
+
+    const char** dataPlatformPathNameLower = (const char**)0x143AF6018;
+    *dataPlatformPathNameLower = "dedicatedserver";*/
+}
+
+void GameSimulationSpawnServerHk(void* inst, ServerSpawnInfo& createInfo)
+{
+    static const auto trampoline = HookManager::Call(GameSimulationSpawnServerHk);
+    KYBER_LOG(Trace, "[GameSim] Spawning server: " << createInfo.isDedicated);
+    return trampoline(inst, createInfo);
+}
+
+void GameSimulationInitDedicatedServerHk(void* inst, void* createInfo)
+{
+    KYBER_LOG(Info, "[GameSim] Initializing Dedicated Server");
+
+    if (!g_program->m_server->m_creationInfo)
+    {
+        KYBER_LOG(Error, "[GameSim] Failed to find server creation info; halting");
+        return;
+    }
+
+    if (g_program->m_server->m_socketManager == nullptr)
+    {
+        g_program->m_server->m_socketManager = (SocketManager*)FB_STATIC_ARENA->alloc(448);
+        if (g_program->m_server->m_socketManager == nullptr)
+        {
+            KYBER_LOG(Error, "[GameSim] Failed to allocate socket manager; halting");
+            return;
+        }
+
+        DirtySockSocketManager_ctor(g_program->m_server->m_socketManager, FB_STATIC_ARENA, 1168);
+    }
+
+    NetworkSettings* networkSettings = Settings<NetworkSettings>("Network");
+    networkSettings->MaxClientCount = 64;
+
+    GameSettings* gameSettings = Settings<GameSettings>("Game");
+    gameSettings->MaxSpectatorCount = 4;
+
+    NetObjectSystemSettings* netObjectSettings = Settings<NetObjectSystemSettings>("NetObjectSystem");
+    netObjectSettings->MaxServerConnectionCount = 64;
+    // netObjectSettings->DeltaCompressionSettings.IsEnabled = false;
+
+    if (g_program->m_server->m_onlineMode)
+    {
+        g_program->m_server->Register();
+    }
+
+    g_program->m_server->m_socketSpawnInfo = SocketSpawnInfo(false, "", g_program->m_server->m_serverId, "");
+
+    MapRotationEntry rotation = g_program->m_server->m_mapRotation.GetNextEntry();
+
+    LevelSetup levelSetup;
+    InitLevelSetup(
+        &levelSetup, g_program->m_server->m_creationInfo->level.c_str(), g_program->m_server->m_creationInfo->mode.c_str(), "", "");
+
+    WSGameSettings* wsSettings = Settings<WSGameSettings>("Whiteshark");
+    wsSettings->AutoBalanceTeamsOnNeutral = true;
+
+    ServerSpawnInfo spawnInfo(levelSetup);
+    spawnInfo.isSinglePlayer = false;
+    spawnInfo.isLocalHost = false;
+    spawnInfo.isDedicated = true;
+    spawnInfo.saveData.init(0);
+    GameSimulationSpawnServerHk(inst, spawnInfo);
+}
+
+class GameSimulation
+{
+public:
+    char pad_0000[256];       // 0x0000
+    uint32_t unk1;            // 0x0100
+    uint32_t m_tickFrequency; // 0x0104
+    uint32_t m_looping;       // 0x0108
+};
+
+void GameSimulationInitHk(GameSimulation* inst, void* createInfo)
+{
+    static const auto trampoline = HookManager::Call(GameSimulationInitHk);
+    KYBER_LOG(Info, "[GameSim] Initializing Game Simulation");
+
+    if (g_program->m_isDedicatedServer)
+    {
+        PlatformUtils::HookVTableFunction(inst, &GameSimulationInitDedicatedServerHk, 31);
+    }
+
+    // Changeable, but causes some weird things.
+    // In Battlefield, this works properly when paired
+    // with changing Server.OutgoingHighFrequency,
+    // but the equivalent settings (Server.OutgoingFrequency,
+    // Server.IncomingFrequency, Client.OutgoingFrequency,
+    // Client.IncomingFrequency, GameTime.MaxSimFps,
+    // GameTime.ForceSimRate) in battlefront just cause
+    // the player to not spawn properly.
+    // inst->m_tickFrequency = 30;
+
+    trampoline(inst, createInfo);
+    KYBER_LOG(Info, "[GameSim] Game Simulation initialized: " << std::hex << inst);
+
+    // GenericUpdateManager::Get().GameSimInit();
+}
+
 const char* GetHostIdHk(__int64 inst)
 {
     return std::getenv("EALaunchEAID");
@@ -764,64 +666,6 @@ void FileSuperBundleManagerUpdateConfigHk(FileSuperBundleManager* inst)
     KYBER_LOG(Debug, "SuperBundle config loaded");
 }
 
-__int64 ClientUpdatePassPreFrameHk(void* inst, const UpdateParameters& params)
-{
-    static const auto trampoline = HookManager::Call(ClientUpdatePassPreFrameHk);
-    __int64 result = trampoline(inst, params);
-
-    if (g_program->m_entityManager != nullptr)
-    {
-        g_program->m_entityManager->UpdateEntities(Realm_Client, params);
-    }
-
-    for (const auto& listener : g_program->m_clientUpdatePassListeners)
-    {
-        listener->Call(ClientUpdatePass_PreFrame);
-    }
-
-    g_threadExecutor->Process(GameThread_Client);
-
-    if (!g_program->m_server->IsRunning())
-    {
-        g_program->GetAPI()->Update();
-    }
-
-    if (g_program->m_scriptManager != nullptr)
-    {
-        g_program->m_scriptManager->GetEventManager().Fire("Client:UpdatePre", params.simulationDeltaTime.toSecondsAsFloat());
-    }
-
-    GenericUpdateManager::Get().Call(UpdateType_Client_PreFrame, params);
-    return result;
-}
-
-__int64 ClientUpdatePassPostFrameHk(void* inst, const UpdateParameters& params)
-{
-    static const auto trampoline = HookManager::Call(ClientUpdatePassPostFrameHk);
-    __int64 result = trampoline(inst, params);
-
-    for (const auto& listener : g_program->m_clientUpdatePassListeners)
-    {
-        listener->Call(ClientUpdatePass_PostFrame);
-    }
-
-    if (g_program->m_scriptManager != nullptr)
-    {
-        g_program->m_scriptManager->GetEventManager().Fire("Client:UpdatePost", params.simulationDeltaTime.toSecondsAsFloat());
-    }
-
-    GenericUpdateManager::Get().Call(UpdateType_Client_PostFrame, params);
-    return result;
-}
-
-__int64 ClientAuthHk(__int64 a1, OnlineId* a2, unsigned int a3)
-{
-    static const auto trampoline = HookManager::Call(ClientAuthHk);
-    __int64 result = trampoline(a1, a2, a3);
-    KYBER_LOG(Info, "[Client] Joining server authenticated as " << a2->m_nativeData << " " << a2->m_id << " " << a3);
-    return result;
-}
-
 __int64 TeamInfo__isFriendlyHk(int teamA, int teamB)
 {
     static const auto trampoline = HookManager::Call(TeamInfo__isFriendlyHk);
@@ -849,31 +693,23 @@ void DummyLuaTable(void** table)
     }
 }
 
-void Program::RegisterClientUpdatePassListener(ClientUpdatePassListener* listener)
-{
-    m_clientUpdatePassListeners.push_back(listener);
-}
-
 void Program::InitializeGameHooks()
 {
     static void* LuaDummy = HOOK_OFFSET(0x1401840C0);
 
     // clang-format off
     HookTemplate hookOffsets[] = {
-        { OFFSET_CLIENT_STATE_CHANGE, ClientStateChangeHk },
         { OFFSET_ENVIRONMENT_GET_HOST_ID, GetHostIdHk },
         { OFFSET_ENVIRONMENT_GET_HOST_IDENTIFIER, GetHostIdHk },
         { OFFSET_ORIGINSDK_INITIALIZE, OriginSDKInitializeHk },
         { OFFSET_MESSAGEMANAGER_DISPATCH_MESSAGE, MessageManagerDispatchMessageHk },
-        { OFFSET_CLIENTCONNECTION_ONDISCONNECTED, ClientConnectionOnDisconnectedHk },
+        { OFFSET_MAINLOOP_INIT, MainLoopInitHk },
+        //{ OFFSET_MAINLOOP_INITDATAPLATFORM, MainLoopInitDataPlatform },
+        { OFFSET_GAMESIMULATION_INIT, GameSimulationInitHk },
+        { OFFSET_GAMESIMULATION_SPAWNSERVER, GameSimulationSpawnServerHk },
         { OFFSET_READOBFUSCATED, ReadObfuscatedHk },
-        { OFFSET_CLIENTCONNECTION_SENDMESSAGE, ClientConnectionSendMessageHk },
         { OFFSET_GETLOCALIZEDSTRING, GetLocalizedStringInternalHk },
-        { OFFSET_CLIENT_CTOR, ClientCtorHk },
         { OFFSET_FILESUPERBUNDLEMANAGER_UPDATECONFIG, FileSuperBundleManagerUpdateConfigHk },
-        { OFFSET_CLIENT_UPDATEPASSPREFRAME, ClientUpdatePassPreFrameHk },
-        { OFFSET_CLIENT_UPDATEPASSPOSTFRAME, ClientUpdatePassPostFrameHk },
-        { HOOK_OFFSET(0x1418D92B0), ClientAuthHk },
         { OFFSET_MEMORYARENA_LOG, MemoryArenaLog },
         { HOOK_OFFSET(0x146A4BA30), TeamInfo__isFriendlyHk },
 
@@ -929,6 +765,7 @@ void Program::Initialize()
     InitializeGamePatches();
 
     m_server->Initialize();
+    m_client->Initialize();
 
     KYBER_LOG(Info, "[Engine] Kyber post-initialized");
 }

--- a/Module/Source/Core/Server.cpp
+++ b/Module/Source/Core/Server.cpp
@@ -510,6 +510,7 @@ void ServerUpdatePassPreFrameHk(void* inst, const UpdateParameters& params)
 
     g_program->m_server->Heartbeat(params);
     g_threadExecutor->Process(GameThread_Server);
+    g_program->m_server->m_eventManager->ProcessEventQueue();
 
     if (g_program->m_server->IsRunning())
     {

--- a/Module/Source/Core/Server.cpp
+++ b/Module/Source/Core/Server.cpp
@@ -40,15 +40,6 @@
 
 #define OFFSET_APPLY_SETTINGS HOOK_OFFSET(0x1401B31B0)
 
-#define OFFSET_CLIENT_INIT_NETWORK HOOK_OFFSET(0x140A8DE80)
-#define OFFSET_CLIENT_CONNECTTOADDRESS HOOK_OFFSET(0x140CB3990)
-
-#define OFFSET_MAINLOOP_INIT HOOK_OFFSET(0x140186B90)
-#define OFFSET_MAINLOOP_INITDATAPLATFORM HOOK_OFFSET(0x145315E30)
-
-#define OFFSET_GAMESIMULATION_INIT HOOK_OFFSET(0x145315930)
-#define OFFSET_GAMESIMULATION_SPAWNSERVER HOOK_OFFSET(0x14018EE70)
-
 #define OFFSET_SERVER_PATCH 0x140A92F71
 
 namespace Kyber
@@ -133,11 +124,11 @@ void InitLevelSetup(LevelSetup* levelSetup, const char* level, const char* mode,
 }
 
 Server::Server()
-    : m_mainLoopInitEventManager(new EventManager())
-    , m_socketManager()
+    : m_socketManager()
     , m_natClient(nullptr)
     , m_playerManager(nullptr)
     , m_persistenceManager(new PersistenceManager())
+    , m_eventManager(new EventManager())
     , m_socketSpawnInfo(SocketSpawnInfo(false, "", "", ""))
     , m_serverInstance(nullptr)
     , m_onlineMode(IsOnlineMode())
@@ -147,8 +138,7 @@ Server::Server()
     , m_levelLoaded(false)
     , m_latestLoadLevelRequest(LoadLevelRequest())
 {
-    m_mainLoopInitEventManager->RegisterListener<MainLoopInitStartServerEvent>(this);
-    m_mainLoopInitEventManager->RegisterListener<MainLoopInitJoinServerEvent>(this);
+    m_eventManager->RegisterListener<MainLoopInitStartServerEvent>(this);
 
     // Using the dirty sock socket manager makes KYBER servers compatible with non-kyber battlefront clients
     bool useDirtySockSocketManager = std::getenv("KYBER_USE_DIRTY_SOCK") != nullptr;
@@ -445,62 +435,6 @@ __int64 SettingsManagerApplyHk(__int64 inst, __int64* a2, char* script, BYTE* a4
     return result;
 }
 
-bool ClientInitNetworkHk(__int64 inst, bool singleplayer, bool localhost, bool coop, bool hosted)
-{
-    static const auto trampoline = HookManager::Call(ClientInitNetworkHk);
-    KYBER_LOG(Info, "[Client] Client is initializing network, singleplayer: " << singleplayer);
-    if (g_program->m_server->m_runningHosted || strlen(Settings<ClientSettings>("Client")->ServerIp) > 0)
-    {
-        *reinterpret_cast<void**>(inst + 0xA8) =
-            reinterpret_cast<void*>(new SocketManagerCreator(&g_program->m_clientSocketManager, g_program->m_server->m_socketSpawnInfo));
-        KYBER_LOG(Info, "[Client] Using custom socket manager");
-    }
-    return trampoline(inst, singleplayer, localhost, coop, hosted);
-}
-
-void ClientConnectToAddressHk(__int64 inst, const char* ipAddress, const char* serverPassword)
-{
-    static const auto trampoline = HookManager::Call(ClientConnectToAddressHk);
-    SocketSpawnInfo info = g_program->m_server->m_socketSpawnInfo;
-    if (false && g_program->m_joining && info.isProxied)
-    {
-        KYBER_LOG(Info, "[Client] Connecting to server (proxied)");
-        trampoline(inst, (std::string(info.proxyAddress) + ":25201").c_str(), serverPassword);
-    }
-    else
-    {
-        KYBER_LOG(Info, "[Client] Connecting to server " << ipAddress);
-        trampoline(inst, ipAddress, serverPassword);
-    }
-
-    if (g_program->m_joining)
-    {
-        g_program->m_connected = true;
-        g_program->m_joining = false;
-    }
-}
-
-void** OnlineManagerConnectHk(void* inst, const SocketAddr& address)
-{
-    static const auto trampoline = HookManager::Call(OnlineManagerConnectHk);
-
-    StringBuilder builder;
-    char buf[256];
-
-    StringBuilder_ctor(&builder, buf, 256);
-    networkAddressToString(&address, builder);
-
-    KYBER_LOG(Info, "[Client] Connecting to server (2) " << buf);
-
-    // std::ofstream fout;
-    // fout.open("addr.bin", std::ios::binary | std::ios::out);
-
-    // fout.write((char*)&address, sizeof(SocketAddr));
-    // fout.close();
-
-    return trampoline(inst, address);
-}
-
 void ServerPlayerSetTeamIdHk(ServerPlayer* inst, int teamId)
 {
     static const auto trampoline = HookManager::Call(ServerPlayerSetTeamIdHk);
@@ -510,156 +444,6 @@ void ServerPlayerSetTeamIdHk(ServerPlayer* inst, int teamId)
     {
         g_program->GetAPI()->GetServerManagement()->SendPlayerList();
     }
-}
-
-struct MainLoop
-{
-    char pad_0000[8];       // 0x0000
-    bool isDedicatedServer; // 0x0008
-};
-
-void* s_mainLoop = nullptr;
-
-bool MainLoopInitHk(MainLoop* inst)
-{
-    static const auto trampoline = HookManager::Call(MainLoopInitHk);
-    s_mainLoop = inst;
-
-    if (g_program->m_isDedicatedServer)
-    {
-        inst->isDedicatedServer = true;
-    }
-
-    g_program->InitializeConsole();
-
-    if (g_program->m_scriptManager != nullptr)
-    {
-        g_program->m_scriptManager->LoadScripts(PluginRealm_Server);
-    }
-
-    KYBER_LOG(Info, "[Engine] Initializing Game Loop");
-    bool result = trampoline(inst);
-
-    KYBER_LOG(Info, "[Engine] Processing initial events");
-    g_program->m_server->m_mainLoopInitEventManager->ProcessEventQueue();
-
-    if (g_program->m_settingsManager != nullptr)
-    {
-        g_program->m_settingsManager->ApplySettings();
-        g_program->m_server->OnSettingsRegistered();
-    }
-
-    return result;
-}
-
-void MainLoopInitDataPlatform()
-{
-    static const auto trampoline = HookManager::Call(MainLoopInitDataPlatform);
-    trampoline();
-
-    /*const char** dataPlatformPathName = (const char**)0x143AF6010;
-    *dataPlatformPathName = "DedicatedServer";
-
-    const char** dataPlatformPathNameLower = (const char**)0x143AF6018;
-    *dataPlatformPathNameLower = "dedicatedserver";*/
-}
-
-void GameSimulationSpawnServerHk(void* inst, ServerSpawnInfo& createInfo)
-{
-    static const auto trampoline = HookManager::Call(GameSimulationSpawnServerHk);
-    KYBER_LOG(Trace, "[GameSim] Spawning server: " << createInfo.isDedicated);
-    return trampoline(inst, createInfo);
-}
-
-void GameSimulationInitDedicatedServerHk(void* inst, void* createInfo)
-{
-    KYBER_LOG(Info, "[GameSim] Initializing Dedicated Server");
-
-    if (!g_program->m_server->m_creationInfo)
-    {
-        KYBER_LOG(Error, "[GameSim] Failed to find server creation info; halting");
-        return;
-    }
-
-    if (g_program->m_server->m_socketManager == nullptr)
-    {
-        g_program->m_server->m_socketManager = (SocketManager*)FB_STATIC_ARENA->alloc(448);
-        if (g_program->m_server->m_socketManager == nullptr)
-        {
-            KYBER_LOG(Error, "[GameSim] Failed to allocate socket manager; halting");
-            return;
-        }
-
-        DirtySockSocketManager_ctor(g_program->m_server->m_socketManager, FB_STATIC_ARENA, 1168);
-    }
-
-    NetworkSettings* networkSettings = Settings<NetworkSettings>("Network");
-    networkSettings->MaxClientCount = 64;
-
-    GameSettings* gameSettings = Settings<GameSettings>("Game");
-    gameSettings->MaxSpectatorCount = 4;
-
-    NetObjectSystemSettings* netObjectSettings = Settings<NetObjectSystemSettings>("NetObjectSystem");
-    netObjectSettings->MaxServerConnectionCount = 64;
-    // netObjectSettings->DeltaCompressionSettings.IsEnabled = false;
-
-    if (g_program->m_server->m_onlineMode)
-    {
-        g_program->m_server->Register();
-    }
-
-    g_program->m_server->m_socketSpawnInfo = SocketSpawnInfo(false, "", g_program->m_server->m_serverId, "");
-
-    MapRotationEntry rotation = g_program->m_server->m_mapRotation.GetNextEntry();
-
-    LevelSetup levelSetup;
-    InitLevelSetup(
-        &levelSetup, g_program->m_server->m_creationInfo->level.c_str(), g_program->m_server->m_creationInfo->mode.c_str(), "", "");
-
-    WSGameSettings* wsSettings = Settings<WSGameSettings>("Whiteshark");
-    wsSettings->AutoBalanceTeamsOnNeutral = true;
-
-    ServerSpawnInfo spawnInfo(levelSetup);
-    spawnInfo.isSinglePlayer = false;
-    spawnInfo.isLocalHost = false;
-    spawnInfo.isDedicated = true;
-    spawnInfo.saveData.init(0);
-    GameSimulationSpawnServerHk(inst, spawnInfo);
-}
-
-class GameSimulation
-{
-public:
-    char pad_0000[256];       // 0x0000
-    uint32_t unk1;            // 0x0100
-    uint32_t m_tickFrequency; // 0x0104
-    uint32_t m_looping;       // 0x0108
-};
-
-void GameSimulationInitHk(GameSimulation* inst, void* createInfo)
-{
-    static const auto trampoline = HookManager::Call(GameSimulationInitHk);
-    KYBER_LOG(Info, "[GameSim] Initializing Game Simulation");
-
-    if (g_program->m_isDedicatedServer)
-    {
-        PlatformUtils::HookVTableFunction(inst, &GameSimulationInitDedicatedServerHk, 31);
-    }
-
-    // Changeable, but causes some weird things.
-    // In Battlefield, this works properly when paired
-    // with changing Server.OutgoingHighFrequency,
-    // but the equivalent settings (Server.OutgoingFrequency,
-    // Server.IncomingFrequency, Client.OutgoingFrequency,
-    // Client.IncomingFrequency, GameTime.MaxSimFps,
-    // GameTime.ForceSimRate) in battlefront just cause
-    // the player to not spawn properly.
-    // inst->m_tickFrequency = 30;
-
-    trampoline(inst, createInfo);
-    KYBER_LOG(Info, "[GameSim] Game Simulation initialized: " << std::hex << inst);
-
-    // GenericUpdateManager::Get().GameSimInit();
 }
 
 void PresenceBackendManagerAddBackendHk(void* inst, TypeObject* backend)
@@ -903,11 +687,6 @@ void Server::OnEvent(const Event& event)
         const auto& e = event.as<MainLoopInitStartServerEvent>();
         m_creationInfo = e.info;
     }
-    else if (event.is<MainLoopInitJoinServerEvent>())
-    {
-        const auto& e = event.as<MainLoopInitJoinServerEvent>();
-        g_program->JoinServer(e.id, e.ip, e.port, e.spectate, e.proxied, false);
-    }
 }
 
 void Server::OnSettingsRegistered()
@@ -915,15 +694,10 @@ void Server::OnSettingsRegistered()
 }
 
 HookTemplate clientServerHookOffsets[] = {
-    { OFFSET_MAINLOOP_INIT, MainLoopInitHk },
     { OFFSET_SERVER_CONSTRUCTOR, ServerCtorHk },
     { OFFSET_SERVER_START, ServerStartHk },
-    { OFFSET_GAMESIMULATION_INIT, GameSimulationInitHk },
     { OFFSET_SERVERPLAYER_SETTEAMID, ServerPlayerSetTeamIdHk },
     { OFFSET_APPLY_SETTINGS, SettingsManagerApplyHk },
-    { OFFSET_CLIENT_INIT_NETWORK, ClientInitNetworkHk },
-    { OFFSET_CLIENT_CONNECTTOADDRESS, ClientConnectToAddressHk },
-    { HOOK_OFFSET(0x140CB3640), OnlineManagerConnectHk },
     { HOOK_OFFSET(0x1478F8440), PresenceBackendManagerAddBackendHk },
     { HOOK_OFFSET(0x1418CA790), LoadSomethingHk },
     //{ HOOK_OFFSET(0x145FE09E0), ProtoHttpControlHk },
@@ -939,11 +713,7 @@ HookTemplate clientServerHookOffsets[] = {
 };
 
 HookTemplate dedicatedServerHookOffsets[] = {
-    { OFFSET_MAINLOOP_INIT, MainLoopInitHk },
     { OFFSET_SERVER_CONSTRUCTOR, ServerCtorHk },
-    //{ OFFSET_MAINLOOP_INITDATAPLATFORM, MainLoopInitDataPlatform },
-    { OFFSET_GAMESIMULATION_INIT, GameSimulationInitHk },
-    { OFFSET_GAMESIMULATION_SPAWNSERVER, GameSimulationSpawnServerHk },
     { OFFSET_SERVERPLAYER_SETTEAMID, ServerPlayerSetTeamIdHk },
     { HOOK_OFFSET(0x1484213F0), GetSocketManagerHk },
     { HOOK_OFFSET(0x1478F8440), PresenceBackendManagerAddBackendHk },

--- a/Module/Source/Network/UDPSocket.cpp
+++ b/Module/Source/Network/UDPSocket.cpp
@@ -239,7 +239,7 @@ bool UDPSocket::Listen(const SocketAddr& address, bool blocking)
     if (m_info.isProxied && m_direction == ProtocolDirection::Serverbound)
     {
         m_sockets.push_back(WebSocket("client", 0, m_proxyQueue));
-        m_sockets.back().ConnectAsClient(m_info.proxyAddress, g_program->m_joinToken);
+        m_sockets.back().ConnectAsClient(m_info.proxyAddress, g_program->m_client->m_joinToken);
     }
     else if (m_direction == ProtocolDirection::Clientbound && g_program->m_server->IsRunning() && g_program->m_server->m_onlineMode)
     {
@@ -247,7 +247,7 @@ bool UDPSocket::Listen(const SocketAddr& address, bool blocking)
         if (pinnedProxy != nullptr)
         {
             m_sockets.push_back(WebSocket("pinned", 0, m_proxyQueue));
-            m_sockets.back().ConnectAsServer(pinnedProxy, g_program->m_joinToken);
+            m_sockets.back().ConnectAsServer(pinnedProxy, g_program->m_client->m_joinToken);
         }
         else
         {
@@ -258,7 +258,7 @@ bool UDPSocket::Listen(const SocketAddr& address, bool blocking)
             for (const auto& proxy : proxies)
             {
                 m_sockets.push_back(WebSocket(proxy.id(), id++, m_proxyQueue));
-                m_sockets.back().ConnectAsServer(proxy.ip(), g_program->m_joinToken);
+                m_sockets.back().ConnectAsServer(proxy.ip(), g_program->m_client->m_joinToken);
             }
         }
     }

--- a/Module/Source/RPC/API/Launcher.cpp
+++ b/Module/Source/RPC/API/Launcher.cpp
@@ -66,7 +66,7 @@ void LauncherInterface::Initialize() const
 
         auto* event = new MainLoopInitStartServerEvent();
         event->info = info;
-        g_program->m_server->m_mainLoopInitEventManager->QueueEvent(event);
+        g_program->m_server->m_eventManager->QueueEvent(event);
         break;
     }
     case kyber_interface::InitializeRequest::kJoinServer: {
@@ -79,8 +79,8 @@ void LauncherInterface::Initialize() const
         event->spectate = joinServer.spectate();
         event->proxied = joinServer.type() == kyber_interface::JoinServerType::PROXIED;
         event->password = "";
-        g_program->m_joinToken = joinServer.jointoken();
-        g_program->m_server->m_mainLoopInitEventManager->QueueEvent(event);
+        g_program->m_client->m_joinToken = joinServer.jointoken();
+        g_program->m_client->m_eventManager->QueueEvent(event);
         break;
     }
     case kyber_interface::InitializeRequest::STARTSTATE_NOT_SET:

--- a/Module/Source/RPC/API/ServerBrowser.cpp
+++ b/Module/Source/RPC/API/ServerBrowser.cpp
@@ -110,7 +110,7 @@ std::optional<std::string> ServerBrowserAPI::RegisterServer(const ServerCreation
         return std::nullopt;
     }
 
-    g_program->m_joinToken = response.proxytoken();
+    g_program->m_client->m_joinToken = response.proxytoken();
 
     return response.id();
 }

--- a/Module/Source/RPC/Interface/ClientState.cpp
+++ b/Module/Source/RPC/Interface/ClientState.cpp
@@ -18,7 +18,7 @@ using namespace kyber_interface;
 ServerUnaryReactor* ClientInterfaceService::JoinServer( 
     CallbackServerContext* context, const JoinServerRequest* request, kyber_common::Empty* response)
 {
-    g_program->JoinServer(request->id(), request->ip(), request->port(), request->spectate(),
+    g_program->m_client->JoinServer(request->id(), request->ip(), request->port(), request->spectate(),
         request->type() == kyber_interface::JoinServerType::PROXIED, true);
 
     ServerUnaryReactor* reactor = context->DefaultReactor();
@@ -31,7 +31,7 @@ ServerUnaryReactor* ClientInterfaceService::SetVoipSettings(CallbackServerContex
 {
     KYBER_LOG(Info, "[RPC] Setting VoIP settings");
 
-    VoipManager* voipManager = g_program->m_voipManager;
+    VoipManager* voipManager = g_program->m_client->m_voipManager;
     if (!voipManager)
     {
         KYBER_LOG(Warning, "[RPC] VoIP manager not initialized");
@@ -55,7 +55,7 @@ ServerUnaryReactor* ClientInterfaceService::SetVoipSettings(CallbackServerContex
 
     if (request->enabled())
     {
-        g_program->AttemptJoinVoip();
+        g_program->m_client->AttemptJoinVoip();
     }
     else
     {
@@ -70,7 +70,7 @@ ServerUnaryReactor* ClientInterfaceService::SetVoipSettings(CallbackServerContex
 ServerUnaryReactor* ClientInterfaceService::GetVoipSettings(CallbackServerContext* context,
     const kyber_common::Empty* request, kyber_interface::VoipSettings* response)
 {
-    VoipManager* voipManager = g_program->m_voipManager;
+    VoipManager* voipManager = g_program->m_client->m_voipManager;
     if (!voipManager)
     {
         KYBER_LOG(Warning, "VoIP manager not initialized");

--- a/Module/Source/RPC/Interface/Common.cpp
+++ b/Module/Source/RPC/Interface/Common.cpp
@@ -47,12 +47,13 @@ ServerUnaryReactor* CommonInterfaceService::GetInfo(
             protoPlayer->set_teamid(player->m_teamId);
         }
     }
-    else if (g_program->m_connected)
+    else if (g_program->m_client->m_connected)
     {
         response->mutable_client()->set_serverid(g_program->m_server->m_socketSpawnInfo.serverName);
     }
 
-    bool vivoxInitialized = g_program->m_voipManager != nullptr && !g_program->m_voipManager->GetRenderDevices().empty();
+    bool vivoxInitialized =
+        g_program->m_client->m_voipManager != nullptr && !g_program->m_client->m_voipManager->GetRenderDevices().empty();
     response->set_vivoxinitialized(vivoxInitialized);
 
     reactor->Finish(Status::OK);

--- a/Module/Source/Voip/UI/KyberVoipPlayerStatusEntity.cpp
+++ b/Module/Source/Voip/UI/KyberVoipPlayerStatusEntity.cpp
@@ -41,7 +41,7 @@ void KyberVoipPlayerStatusEntity::Update(const UpdateParameters& params)
         return;
     }
 
-    bool isPlayerSpeaking = g_program->m_voipManager->IsParticipantSpeaking(m_currentPlayer);
+    bool isPlayerSpeaking = g_program->m_client->m_voipManager->IsParticipantSpeaking(m_currentPlayer);
     m_isPlayerTalking = &isPlayerSpeaking;
 
     // KYBER_LOG(Trace, "[VoIP] Speaking Status for " << m_currentPlayer << " is " << isPlayerSpeaking);

--- a/Module/Source/Voip/UI/KyberVoipSettingsEntity.cpp
+++ b/Module/Source/Voip/UI/KyberVoipSettingsEntity.cpp
@@ -27,9 +27,9 @@ void KyberVoipSettingsEntity::PropertyChanged(PropertyModification* modification
         float newVolume = round(*reinterpret_cast<float*>(modification->value) * 100);
         KYBER_LOG(Info, "Voip volume changed: " << newVolume);
 
-        if (g_program->m_voipManager != nullptr)
+        if (g_program->m_client->m_voipManager != nullptr)
         {
-            g_program->m_voipManager->SetInputVolume(newVolume);
+            g_program->m_client->m_voipManager->SetInputVolume(newVolume);
         }
     }
 }

--- a/Module/Source/Voip/VoipManager.cpp
+++ b/Module/Source/Voip/VoipManager.cpp
@@ -29,13 +29,13 @@ void OnSdkMessageAvailable(void* callbackHandle)
 
 void VoipMuteCommand(ConsoleContext& cc)
 {
-    VoipManager* manager = g_program->m_voipManager;
+    VoipManager* manager = g_program->m_client->m_voipManager;
     manager->SetMuted(true);
 }
 
 void VoipListCaptureDevicesCommand(ConsoleContext& cc)
 {
-    VoipManager* manager = g_program->m_voipManager;
+    VoipManager* manager = g_program->m_client->m_voipManager;
     cc << "Capture devices:\n";
 
     int i = 0;
@@ -50,7 +50,7 @@ void VoipListCaptureDevicesCommand(ConsoleContext& cc)
 
 void VoipSetCaptureDeviceCommand(ConsoleContext& cc)
 {
-    VoipManager* manager = g_program->m_voipManager;
+    VoipManager* manager = g_program->m_client->m_voipManager;
 
     auto stream = cc.stream();
     int id;
@@ -64,7 +64,7 @@ void VoipSetCaptureDeviceCommand(ConsoleContext& cc)
 
 void VoipSetInputVolumeCommand(ConsoleContext& cc)
 {
-    VoipManager* manager = g_program->m_voipManager;
+    VoipManager* manager = g_program->m_client->m_voipManager;
 
     auto stream = cc.stream();
     float volume;
@@ -76,7 +76,7 @@ void VoipSetInputVolumeCommand(ConsoleContext& cc)
 
 void VoipSetSpeakerVolumeCommand(ConsoleContext& cc)
 {
-    VoipManager* manager = g_program->m_voipManager;
+    VoipManager* manager = g_program->m_client->m_voipManager;
 
     auto stream = cc.stream();
     float volume;
@@ -122,7 +122,7 @@ VoipManager::VoipManager()
 {
     RegisterRenderListener(this);
 
-    g_program->RegisterClientUpdatePassListener(this);
+    g_program->m_client->RegisterClientUpdatePassListener(this);
     g_program->m_consoleRegistrationCallbacks.push_back([&]() {
         RegisterConsoleCommand(&VoipMuteCommand, "VoipMute", "");
         RegisterConsoleCommand(&VoipListCaptureDevicesCommand, "VoipListCaptureDevices", "");
@@ -295,7 +295,7 @@ void VoipManager::Call(ClientUpdatePass pass)
         return;
     }
 
-    if (g_program->m_clientState != ClientState_Ingame)
+    if (g_program->m_client->m_clientState != ClientState_Ingame)
     {
         return;
     }


### PR DESCRIPTION
- Moves everything that is client-related in either the `Server` or `Program` classes into a proper designated `Client` class
- Removes `m_mainLoopInitEventManager` entirely, and in its stead, both the client and server have their own event manager that listens to the initialization events
- A few hooks are moved from `Server` to `Program` as they are for both client & server