### PR TITLE
[API] Fix RWMutex double unlock panic in ServerManager

### DIFF
--- a/API/pkg/ws/server_manager.go
+++ b/API/pkg/ws/server_manager.go
@@ -421,7 +421,6 @@ func (sm *ServerManager) HandleServerWS(w http.ResponseWriter, r *http.Request) 
 		}
 
 		delete(sm.ownedServers, id)
-		sm.mu.Unlock()
 	}
 
 	sm.ownedServers[id] = &OwnedServer{Conn: conn}


### PR DESCRIPTION
Remove redundant RWMutex.Unlock() call in HandleServerWS that caused a fatal panic when replacing an existing connection for an already-owned server