### PR TITLE
[Module] add KyberDateTimeEntityData

### DIFF
--- a/Module/Public/Entity/Entities/KyberDateTimeEntity.h
+++ b/Module/Public/Entity/Entities/KyberDateTimeEntity.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <Entity/NativeEntityManager.h>
+
+namespace Kyber
+{
+class KyberDateTimeEntityData : public EntityData
+{
+public:
+    bool UseUtc;
+    int32_t Month;
+    int32_t Day;
+    int32_t Hour;
+    int32_t Minute;
+};
+
+class KyberDateTimeEntity : public KyberEntity<KyberDateTimeEntityData>
+{
+public:
+    KyberDateTimeEntity(EntityManager* entityManager, NativeEntity* entity, KyberDateTimeEntityData* data);
+
+    void Event(EntityEvent* event) override;
+    void PropertyChanged(PropertyModification* modification) override;
+
+private:
+    void UpdateDateTime(bool useUtc);
+};
+} // namespace Kyber

--- a/Module/Source/Entity/Entities/KyberDateTimeEntity.cpp
+++ b/Module/Source/Entity/Entities/KyberDateTimeEntity.cpp
@@ -1,0 +1,78 @@
+#include <Entity/Entities/KyberDateTimeEntity.h>
+#include <Core/Program.h>
+
+#include <chrono>
+#include <ctime>
+
+namespace Kyber
+{
+KB_IMPLEMENT_TYPE(KyberDateTimeEntityData)
+{
+    KyberTypeInfo info("KyberDateTimeEntityData", "EntityData");
+    info.AddField("Boolean", "UseUtc");
+    info.AddField("Int32", "Month");
+    info.AddField("Int32", "Day");
+    info.AddField("Int32", "Hour");
+    info.AddField("Int32", "Minute");
+    return info;
+}
+
+KB_IMPLEMENT_ENTITY(KyberDateTimeEntity, KyberDateTimeEntityData);
+
+KyberDateTimeEntity::KyberDateTimeEntity(EntityManager* entityManager, NativeEntity* entity, KyberDateTimeEntityData* data)
+    : KyberEntity(entity, data)
+{
+    UpdateDateTime(data->UseUtc);
+}
+
+void KyberDateTimeEntity::Event(EntityEvent* event)
+{
+    if (event->Is("Update"))
+    {
+        KYBER_LOG(Info, "[Module] Updating time for date time entity");
+        UpdateDateTime(GetData()->UseUtc);
+    }
+}
+
+void KyberDateTimeEntity::PropertyChanged(PropertyModification* modification)
+{
+    if (modification->Is("UseUtc"))
+    {
+        bool useUtc = *reinterpret_cast<bool*>(modification->value);
+        UpdateDateTime(useUtc);
+    }
+}
+
+void KyberDateTimeEntity::UpdateDateTime(bool useUtc)
+{
+    auto now = std::chrono::system_clock::now();
+    std::time_t now_c = std::chrono::system_clock::to_time_t(now);
+    std::tm* time_info;
+
+    if (useUtc)
+    {
+        time_info = std::gmtime(&now_c);
+    }
+    else
+    {
+        time_info = std::localtime(&now_c);
+    }
+
+    if (time_info)
+    {
+        const TypeInfo* int32Type = g_program->m_entityManager->GetNativeType("Int32");
+        if (int32Type)
+        {
+            int32_t month = time_info->tm_mon + 1;
+            int32_t day = time_info->tm_mday;
+            int32_t hour = time_info->tm_hour;
+            int32_t minute = time_info->tm_min;
+
+            WriteField("Month", int32Type, &month);
+            WriteField("Day", int32Type, &day);
+            WriteField("Hour", int32Type, &hour);
+            WriteField("Minute", int32Type, &minute);
+        }
+    }
+}
+} // namespace Kyber

--- a/Module/Source/Entity/Entities/KyberDateTimeEntity.cpp
+++ b/Module/Source/Entity/Entities/KyberDateTimeEntity.cpp
@@ -27,20 +27,24 @@ KyberDateTimeEntity::KyberDateTimeEntity(EntityManager* entityManager, NativeEnt
 
 void KyberDateTimeEntity::Event(EntityEvent* event)
 {
-    if (event->Is("Update"))
+    if (!event->Is("Update"))
     {
-        KYBER_LOG(Info, "[Module] Updating time for date time entity");
-        UpdateDateTime(GetData()->UseUtc);
+        return;
     }
+
+    KYBER_LOG(Info, "[Module] Updating time for date time entity");
+    UpdateDateTime(GetData()->UseUtc);
 }
 
 void KyberDateTimeEntity::PropertyChanged(PropertyModification* modification)
 {
-    if (modification->Is("UseUtc"))
+    if (!modification->Is("UseUtc"))
     {
-        bool useUtc = *reinterpret_cast<bool*>(modification->value);
-        UpdateDateTime(useUtc);
+        return;
     }
+
+    bool useUtc = *reinterpret_cast<bool*>(modification->value);
+    UpdateDateTime(useUtc);
 }
 
 void KyberDateTimeEntity::UpdateDateTime(bool useUtc)
@@ -58,21 +62,25 @@ void KyberDateTimeEntity::UpdateDateTime(bool useUtc)
         time_info = std::localtime(&now_c);
     }
 
-    if (time_info)
+    if (!time_info)
     {
-        const TypeInfo* int32Type = g_program->m_entityManager->GetNativeType("Int32");
-        if (int32Type)
-        {
-            int32_t month = time_info->tm_mon + 1;
-            int32_t day = time_info->tm_mday;
-            int32_t hour = time_info->tm_hour;
-            int32_t minute = time_info->tm_min;
-
-            WriteField("Month", int32Type, &month);
-            WriteField("Day", int32Type, &day);
-            WriteField("Hour", int32Type, &hour);
-            WriteField("Minute", int32Type, &minute);
-        }
+        return;
     }
+
+    const TypeInfo* int32Type = g_program->m_entityManager->GetNativeType("Int32");
+    if (!int32Type)
+    {
+        return;
+    }
+
+    int32_t month = time_info->tm_mon + 1;
+    int32_t day = time_info->tm_mday;
+    int32_t hour = time_info->tm_hour;
+    int32_t minute = time_info->tm_min;
+
+    WriteField("Month", int32Type, &month);
+    WriteField("Day", int32Type, &day);
+    WriteField("Hour", int32Type, &hour);
+    WriteField("Minute", int32Type, &minute);
 }
 } // namespace Kyber

--- a/Module/Source/Entity/Entities/KyberDateTimeEntity.cpp
+++ b/Module/Source/Entity/Entities/KyberDateTimeEntity.cpp
@@ -32,7 +32,7 @@ void KyberDateTimeEntity::Event(EntityEvent* event)
         return;
     }
 
-    KYBER_LOG(Info, "[Module] Updating time for date time entity");
+    // KYBER_LOG(Info, "[Module] Updating time for date time entity");
     UpdateDateTime(GetData()->UseUtc);
 }
 


### PR DESCRIPTION
**Why?** Embedded April fools pranks, other holiday features, real world accurate lighting variant selection, etc.

I originally posted the idea on [Discord](https://discord.com/channels/305338604316655616/934143005181497446/1424238289711534190) (#patreon-chat), then later on [feedback site](https://feedback.kyber.gg/p/an-entity-that-provides-the-current-date-and-time-as) (marked as Planned).

```cs
KyberDateTimeEntityData : dummyData
{
    Boolean UseUtc;   //         (Input)
    Int32 Month;      // [1,12]  (Output)
    Int32 Day;        // [1,31]  (Output)
    Int32 Hour;       // [0,23]  (Output)
    Int32 Minute;     // [0,59]  (Output)
}
```

Entity has an input event `Update` which will update the outputs to the current time. (Values do not update by themselves.)
Changing `UseUtc` will also trigger the values to update.