### PR TITLE
[Module] Fix issues with ModLoader

### DIFF
--- a/Module/Source/ModLoader/ModLoader.cpp
+++ b/Module/Source/ModLoader/ModLoader.cpp
@@ -1573,6 +1573,8 @@ void ModLoader::LoadMod(const eastl::string& fileName, const eastl::string& rela
 void ModLoader::FinalizeModLoads()
 {
     KYBER_LOG(Debug, "[ModLoader] Finalizing mod resources");
+
+    // Reorder mods, from highest priority to lowest
     KYBER_LOG(Debug, "[ModLoader] Finalizing: Stage 1");
 
     m_modResources.clear();
@@ -1589,9 +1591,11 @@ void ModLoader::FinalizeModLoads()
     eastl::stable_sort(
         m_modResources.begin(), m_modResources.end(), [](const ModResource& a, const ModResource& b) { return a.type < b.type; });
 
+    // Collect highest priority resources, to override lower priority resources
     KYBER_LOG(Debug, "[ModLoader] Finalizing: Stage 2");
 
     eastl::unordered_map<uint32_t, ModResourceData> sources;
+    eastl::map<uint32_t, const ModResource*> globalOverrides;
 
     for (auto& resource : m_modResources)
     {
@@ -1606,8 +1610,10 @@ void ModLoader::FinalizeModLoads()
         }
 
         sources[resource.uniqueIdWithType] = resource.data;
+        globalOverrides[resource.uniqueIdWithType] = &resource;
     }
 
+    // Set modified data for resources that don't have any modified data themselve, if some other mod modifies the same resource
     KYBER_LOG(Debug, "[ModLoader] Finalizing: Stage 3");
 
     for (auto& resource : m_modResources)
@@ -1670,9 +1676,8 @@ void ModLoader::FinalizeModLoads()
         m_bundleResources[entry.first].reserve(entry.second);
     }
 
+    // Add resources to bundles
     KYBER_LOG(Debug, "[ModLoader] Finalizing: Stage 7");
-
-    eastl::map<uint32_t, const ModResource*> globalOverrides;
 
     eastl::map<uint32_t, eastl::set<uint32_t>> visitedNames;
     for (const auto& resource : m_modResources)
@@ -1684,11 +1689,8 @@ void ModLoader::FinalizeModLoads()
 
         const ModResource* assignableResource = &resource;
 
-        if (resource.bundles.empty())
-        {
-            globalOverrides[resource.uniqueIdWithType] = assignableResource;
-        }
-        else
+	// Replace resource by higher priority resource
+        if (!resource.bundles.empty())
         {
             auto it = globalOverrides.find(assignableResource->uniqueIdWithType);
             if (it != globalOverrides.end())

--- a/Module/Source/ModLoader/ModLoader.cpp
+++ b/Module/Source/ModLoader/ModLoader.cpp
@@ -1689,7 +1689,7 @@ void ModLoader::FinalizeModLoads()
 
         const ModResource* assignableResource = &resource;
 
-	// Replace resource by higher priority resource
+        // Replace resource by higher priority resource
         if (!resource.bundles.empty())
         {
             auto it = globalOverrides.find(assignableResource->uniqueIdWithType);

--- a/Module/Source/ModLoader/ResourceMerger.cpp
+++ b/Module/Source/ModLoader/ResourceMerger.cpp
@@ -418,17 +418,17 @@ public:
             hashes.push_back(resources[i]->m_hash);
         }
 
-	// Replace entries that are modified
+        // Replace entries that are modified
         for (int i = 0; i < m_hashes.size(); ++i)
         {
-            size_t indexOf = eastl::find(hashes.begin(), hashes.end(), m_hashes[i]) - hashes.begin();
-            if (indexOf != hashes.size())
+            size_t hashIndex = eastl::find(hashes.begin(), hashes.end(), m_hashes[i]) - hashes.begin();
+            if (hashIndex != hashes.size())
             {
-                m_resources[i] = resources[indexOf];
+                m_resources[i] = resources[hashIndex];
             }
         }
 
-	// Add entries that are not in the original asset
+        // Add entries that are not in the original asset
         for (int i = 0; i < hashes.size(); ++i)
         {
             if (!ContainsHash(hashes[i]))

--- a/Module/Source/ModLoader/ResourceMerger.cpp
+++ b/Module/Source/ModLoader/ResourceMerger.cpp
@@ -418,14 +418,17 @@ public:
             hashes.push_back(resources[i]->m_hash);
         }
 
+	// Replace entries that are modified
         for (int i = 0; i < m_hashes.size(); ++i)
         {
-            if (ContainsHash(m_hashes[i]))
+            size_t indexOf = eastl::find(hashes.begin(), hashes.end(), m_hashes[i]) - hashes.begin();
+            if (indexOf != hashes.size())
             {
-                m_resources[i] = resources[i];
+                m_resources[i] = resources[indexOf];
             }
         }
 
+	// Add entries that are not in the original asset
         for (int i = 0; i < hashes.size(); ++i)
         {
             if (!ContainsHash(hashes[i]))


### PR DESCRIPTION
This fixes two issues:

- The ShaderBlockDepot handler did not replace modified entries correctly
- The ModLoader did not replace lower priority resources with the higher priority one in the added bundles of the lower priority resource