### PR TITLE
[API] Fix missing user field in server punishments

### DIFF
--- a/API/internal/rpc/server_management.go
+++ b/API/internal/rpc/server_management.go
@@ -97,6 +97,8 @@ func (s *ServerManagement) GetPunishments(ctx context.Context, req *pbapi.Punish
 			continue
 		}
 
+		punishment.UserModel = user
+
 		convPunishments = append(convPunishments, punishment.Proto())
 	}
 


### PR DESCRIPTION
Fixes the API not populating the user field when fetching punishments. The launcher can now display user ID and name for punishments again