### PR TITLE
[Module] feat: add KyberCurrentTimeEntity, KyberTimeSplitterEntity

### DIFF
--- a/Module/Public/Entity/Entities/KyberCurrentTimeEntity.h
+++ b/Module/Public/Entity/Entities/KyberCurrentTimeEntity.h
@@ -9,7 +9,7 @@ namespace Kyber
 class KyberCurrentTimeEntityData : public EntityData
 {
 public:
-    bool AlwaysUpdate;
+    bool EnableUpdates;
 };
     
 class KyberCurrentTimeEntity : public KyberEntity<KyberCurrentTimeEntityData>

--- a/Module/Public/Entity/Entities/KyberCurrentTimeEntity.h
+++ b/Module/Public/Entity/Entities/KyberCurrentTimeEntity.h
@@ -1,0 +1,27 @@
+// Copyright Armchair Developers. Licensed under GPLv3.
+
+#pragma once
+
+#include <Entity/NativeEntityManager.h>
+
+namespace Kyber
+{
+class KyberCurrentTimeEntityData : public EntityData
+{
+public:
+    bool AlwaysUpdate;
+};
+    
+class KyberCurrentTimeEntity : public KyberEntity<KyberCurrentTimeEntityData>
+{
+public:
+    KyberCurrentTimeEntity(EntityManager* entityManager, NativeEntity* entity, KyberCurrentTimeEntityData* data);
+
+    void Event(EntityEvent* event) override;
+    void Update(const UpdateParameters& params) override;
+    float GetTime();
+
+private:
+    PropertyWriter<float> m_timeOut;
+};
+} // namespace Kyber

--- a/Module/Public/Entity/Entities/KyberTimeSplitterEntity.h
+++ b/Module/Public/Entity/Entities/KyberTimeSplitterEntity.h
@@ -20,13 +20,9 @@ public:
     void PropertyChanged(PropertyModification* modification) override;
     
 private:
-    PropertyWriter<char*> m_dateStrOut;
     PropertyWriter<int> m_secIntOut;
     PropertyWriter<int> m_minIntOut;
     PropertyWriter<int> m_hourIntOut;
-    PropertyWriter<char*> m_dayStrOut;
-    PropertyWriter<char*> m_monthStrOut;
-    PropertyWriter<char*> m_yearStrOut;
     PropertyWriter<int> m_dayIntOut;
     PropertyWriter<int> m_monthIntOut;
     PropertyWriter<int> m_yearIntOut;

--- a/Module/Public/Entity/Entities/KyberTimeSplitterEntity.h
+++ b/Module/Public/Entity/Entities/KyberTimeSplitterEntity.h
@@ -1,0 +1,34 @@
+// Copyright Armchair Developers. Licensed under GPLv3.
+
+#pragma once
+
+#include <Entity/NativeEntityManager.h>
+
+namespace Kyber
+{
+class KyberTimeSplitterEntityData : public EntityData
+{
+public:
+    bool UseUTC;
+};
+    
+class KyberTimeSplitterEntity : public KyberEntity<KyberTimeSplitterEntityData>
+{
+public:
+    KyberTimeSplitterEntity(EntityManager* entityManager, NativeEntity* entity, KyberTimeSplitterEntityData* data);
+
+    void PropertyChanged(PropertyModification* modification) override;
+    
+private:
+    PropertyWriter<char*> m_dateStrOut;
+    PropertyWriter<int> m_secIntOut;
+    PropertyWriter<int> m_minIntOut;
+    PropertyWriter<int> m_hourIntOut;
+    PropertyWriter<char*> m_dayStrOut;
+    PropertyWriter<char*> m_monthStrOut;
+    PropertyWriter<char*> m_yearStrOut;
+    PropertyWriter<int> m_dayIntOut;
+    PropertyWriter<int> m_monthIntOut;
+    PropertyWriter<int> m_yearIntOut;
+};
+} // namespace Kyber

--- a/Module/Source/Entity/Entities/KyberCurrentTimeEntity.cpp
+++ b/Module/Source/Entity/Entities/KyberCurrentTimeEntity.cpp
@@ -1,0 +1,51 @@
+// Copyright Armchair Developers. Licensed under GPLv3.
+
+#include <Entity/Entities/KyberCurrentTimeEntity.h>
+
+#include <Core/Program.h>
+
+#include <chrono>
+
+namespace Kyber
+{
+KB_IMPLEMENT_TYPE(KyberCurrentTimeEntityData)
+{
+    KyberTypeInfo info("KyberCurrentTimeEntityData", "EntityData");
+    info.AddField("Boolean", "AlwaysUpdate");
+    return info;
+}
+
+KB_IMPLEMENT_ENTITY(KyberCurrentTimeEntity, KyberCurrentTimeEntityData);
+
+KyberCurrentTimeEntity::KyberCurrentTimeEntity(EntityManager* entityManager, NativeEntity* entity, KyberCurrentTimeEntityData* data)
+    : KyberEntity(entity, data)
+{
+    m_timeOut = CreateFieldOverride<float>("Time", g_program->m_entityManager->GetNativeType("Float32"));
+
+    SetWantUpdates(data->AlwaysUpdate);
+}
+
+void KyberCurrentTimeEntity::Event(EntityEvent* event)
+{
+    if (event->Is("Update") && !GetData()->AlwaysUpdate)
+    {
+        float currentTime = GetTime();
+        m_timeOut = &currentTime;
+        FireEvent("OnUpdate");
+    }
+}
+
+void KyberCurrentTimeEntity::Update(const UpdateParameters& params)
+{
+    float currentTime = GetTime();
+    m_timeOut = &currentTime;
+}
+
+float KyberCurrentTimeEntity::GetTime()
+{
+    auto now = std::chrono::system_clock::now();
+    auto duration = now.time_since_epoch();
+    auto seconds = std::chrono::duration_cast<std::chrono::duration<float>>(duration);
+    return seconds.count();
+}
+} // namespace Kyber

--- a/Module/Source/Entity/Entities/KyberCurrentTimeEntity.cpp
+++ b/Module/Source/Entity/Entities/KyberCurrentTimeEntity.cpp
@@ -31,11 +31,7 @@ void KyberCurrentTimeEntity::Event(EntityEvent* event)
     {
         float currentTime = GetTime();
         m_timeOut = &currentTime;
-
-        if (GetData()->EnableUpdates)
-        {
-            FireEvent("OnUpdate");
-        }
+        FireEvent("OnUpdate");
     }
 }
 

--- a/Module/Source/Entity/Entities/KyberCurrentTimeEntity.cpp
+++ b/Module/Source/Entity/Entities/KyberCurrentTimeEntity.cpp
@@ -11,7 +11,7 @@ namespace Kyber
 KB_IMPLEMENT_TYPE(KyberCurrentTimeEntityData)
 {
     KyberTypeInfo info("KyberCurrentTimeEntityData", "EntityData");
-    info.AddField("Boolean", "AlwaysUpdate");
+    info.AddField("Boolean", "EnableUpdates");
     return info;
 }
 
@@ -22,12 +22,12 @@ KyberCurrentTimeEntity::KyberCurrentTimeEntity(EntityManager* entityManager, Nat
 {
     m_timeOut = CreateFieldOverride<float>("Time", g_program->m_entityManager->GetNativeType("Float32"));
 
-    SetWantUpdates(data->AlwaysUpdate);
+    SetWantUpdates(data->EnableUpdates);
 }
 
 void KyberCurrentTimeEntity::Event(EntityEvent* event)
 {
-    if (event->Is("Update") && !GetData()->AlwaysUpdate)
+    if (event->Is("Update") && !GetData()->EnableUpdates)
     {
         float currentTime = GetTime();
         m_timeOut = &currentTime;

--- a/Module/Source/Entity/Entities/KyberCurrentTimeEntity.cpp
+++ b/Module/Source/Entity/Entities/KyberCurrentTimeEntity.cpp
@@ -27,11 +27,15 @@ KyberCurrentTimeEntity::KyberCurrentTimeEntity(EntityManager* entityManager, Nat
 
 void KyberCurrentTimeEntity::Event(EntityEvent* event)
 {
-    if (event->Is("Update") && !GetData()->EnableUpdates)
+    if (event->Is("Update"))
     {
         float currentTime = GetTime();
         m_timeOut = &currentTime;
-        FireEvent("OnUpdate");
+
+        if (GetData()->EnableUpdates)
+        {
+            FireEvent("OnUpdate");
+        }
     }
 }
 

--- a/Module/Source/Entity/Entities/KyberTimeSplitterEntity.cpp
+++ b/Module/Source/Entity/Entities/KyberTimeSplitterEntity.cpp
@@ -57,7 +57,6 @@ void KyberTimeSplitterEntity::PropertyChanged(PropertyModification* modification
         std::chrono::duration_cast<std::chrono::system_clock::duration>(duration)
     );
 
-    // Get 
     std::time_t sysClockTime = std::chrono::system_clock::to_time_t(timePoint);
     std::tm* time = GetData()->UseUTC ? std::gmtime(&sysClockTime) : std::localtime(&sysClockTime);
 

--- a/Module/Source/Entity/Entities/KyberTimeSplitterEntity.cpp
+++ b/Module/Source/Entity/Entities/KyberTimeSplitterEntity.cpp
@@ -20,10 +20,6 @@ KB_IMPLEMENT_ENTITY(KyberTimeSplitterEntity, KyberTimeSplitterEntityData);
 KyberTimeSplitterEntity::KyberTimeSplitterEntity(EntityManager* entityManager, NativeEntity* entity, KyberTimeSplitterEntityData* data)
     : KyberEntity(entity, data)
 {
-    m_dateStrOut = CreateFieldOverride<char*>("DateString", g_program->m_entityManager->GetNativeType("CString"));
-    m_dayStrOut = CreateFieldOverride<char*>("DayString", g_program->m_entityManager->GetNativeType("CString"));
-    m_monthStrOut = CreateFieldOverride<char*>("MonthString", g_program->m_entityManager->GetNativeType("CString"));
-    m_yearStrOut = CreateFieldOverride<char*>("YearString", g_program->m_entityManager->GetNativeType("CString"));
     m_dayIntOut = CreateFieldOverride<int>("DayInt", g_program->m_entityManager->GetNativeType("Int32"));
     m_monthIntOut = CreateFieldOverride<int>("MonthInt", g_program->m_entityManager->GetNativeType("Int32"));
     m_yearIntOut = CreateFieldOverride<int>("YearInt", g_program->m_entityManager->GetNativeType("Int32"));
@@ -37,7 +33,7 @@ void KyberTimeSplitterEntity::PropertyChanged(PropertyModification* modification
     float currentTime = 0;
 
     PropertyReader<float> fieldValue = GetFieldReader<float>("Time");
-    if (fieldValue.HasConnection())
+    if (fieldValue.HasConnectionValue())
     {
         currentTime = fieldValue.Get();
     }
@@ -56,16 +52,6 @@ void KyberTimeSplitterEntity::PropertyChanged(PropertyModification* modification
     std::time_t sysClockTime = std::chrono::system_clock::to_time_t(timePoint);
     std::tm* time = GetData()->UseUTC ? std::gmtime(&sysClockTime) : std::localtime(&sysClockTime);
 
-    // Use strftime to get day/month/year names from dates and save them to a buffer
-    char* dateStr = new char[100];
-    strftime(dateStr, 100, "%A, %B %d, %Y", time);
-    char* dayStr = new char[10];;
-    strftime(dayStr, 10, "%A", time);
-    char* monthStr = new char[10];;
-    strftime(monthStr, 10, "%d", time);
-    char* yearStr = new char[10];;
-    strftime(yearStr, 10, "%Y", time);
-
     // Get Second, Minute, Hour, Day, Month, Year
     int second = time->tm_sec;
     int minute = time->tm_min;
@@ -75,10 +61,6 @@ void KyberTimeSplitterEntity::PropertyChanged(PropertyModification* modification
     int year = time->tm_year + 1900;
 
     // Update property outputs
-    m_dateStrOut = &dateStr;
-    m_dayStrOut = &dayStr;
-    m_monthStrOut = &monthStr;
-    m_yearStrOut = &yearStr;
     m_dayIntOut = &day;
     m_monthIntOut = &month;
     m_yearIntOut = &year;

--- a/Module/Source/Entity/Entities/KyberTimeSplitterEntity.cpp
+++ b/Module/Source/Entity/Entities/KyberTimeSplitterEntity.cpp
@@ -39,11 +39,7 @@ void KyberTimeSplitterEntity::PropertyChanged(PropertyModification* modification
     PropertyReader<float> fieldValue = GetFieldReader<float>("Time");
     if (fieldValue.HasConnection())
     {
-        bool hasValue = fieldValue.HasConnectionValue();
-        if (hasValue)
-        {
-            currentTime = fieldValue.Get();
-        }
+        currentTime = fieldValue.Get();
     }
 
     if (currentTime <= 0)

--- a/Module/Source/Entity/Entities/KyberTimeSplitterEntity.cpp
+++ b/Module/Source/Entity/Entities/KyberTimeSplitterEntity.cpp
@@ -1,0 +1,94 @@
+// Copyright Armchair Developers. Licensed under GPLv3.
+
+#include <Entity/Entities/KyberTimeSplitterEntity.h>
+
+#include <Core/Program.h>
+
+#include <chrono>
+
+namespace Kyber
+{
+KB_IMPLEMENT_TYPE(KyberTimeSplitterEntityData)
+{
+    KyberTypeInfo info("KyberTimeSplitterEntityData", "EntityData");
+    info.AddField("Boolean", "UseUTC");
+    return info;
+}
+
+KB_IMPLEMENT_ENTITY(KyberTimeSplitterEntity, KyberTimeSplitterEntityData);
+
+KyberTimeSplitterEntity::KyberTimeSplitterEntity(EntityManager* entityManager, NativeEntity* entity, KyberTimeSplitterEntityData* data)
+    : KyberEntity(entity, data)
+{
+    m_dateStrOut = CreateFieldOverride<char*>("DateString", g_program->m_entityManager->GetNativeType("CString"));
+    m_dayStrOut = CreateFieldOverride<char*>("DayString", g_program->m_entityManager->GetNativeType("CString"));
+    m_monthStrOut = CreateFieldOverride<char*>("MonthString", g_program->m_entityManager->GetNativeType("CString"));
+    m_yearStrOut = CreateFieldOverride<char*>("YearString", g_program->m_entityManager->GetNativeType("CString"));
+    m_dayIntOut = CreateFieldOverride<int>("DayInt", g_program->m_entityManager->GetNativeType("Int32"));
+    m_monthIntOut = CreateFieldOverride<int>("MonthInt", g_program->m_entityManager->GetNativeType("Int32"));
+    m_yearIntOut = CreateFieldOverride<int>("YearInt", g_program->m_entityManager->GetNativeType("Int32"));
+    m_secIntOut = CreateFieldOverride<int>("SecondInt", g_program->m_entityManager->GetNativeType("Int32"));
+    m_minIntOut = CreateFieldOverride<int>("MinuteInt", g_program->m_entityManager->GetNativeType("Int32"));
+    m_hourIntOut = CreateFieldOverride<int>("HourInt", g_program->m_entityManager->GetNativeType("Int32"));
+}
+
+void KyberTimeSplitterEntity::PropertyChanged(PropertyModification* modification)
+{
+    float currentTime = 0;
+
+    PropertyReader<float> fieldValue = GetFieldReader<float>("Time");
+    if (fieldValue.HasConnection())
+    {
+        bool hasValue = fieldValue.HasConnectionValue();
+        if (hasValue)
+        {
+            currentTime = fieldValue.Get();
+        }
+    }
+
+    if (currentTime <= 0)
+    {
+        return;
+    }
+    
+    // Convert to time_point from float
+    auto duration = std::chrono::duration<float>(currentTime);
+    auto timePoint = std::chrono::system_clock::time_point(
+        std::chrono::duration_cast<std::chrono::system_clock::duration>(duration)
+    );
+
+    // Get 
+    std::time_t sysClockTime = std::chrono::system_clock::to_time_t(timePoint);
+    std::tm* time = GetData()->UseUTC ? std::gmtime(&sysClockTime) : std::localtime(&sysClockTime);
+
+    // Use strftime to get day/month/year names from dates and save them to a buffer
+    char* dateStr = new char[100];
+    strftime(dateStr, 100, "%A, %B %d, %Y", time);
+    char* dayStr = new char[10];;
+    strftime(dayStr, 10, "%A", time);
+    char* monthStr = new char[10];;
+    strftime(monthStr, 10, "%d", time);
+    char* yearStr = new char[10];;
+    strftime(yearStr, 10, "%Y", time);
+
+    // Get Second, Minute, Hour, Day, Month, Year
+    int second = time->tm_sec;
+    int minute = time->tm_min;
+    int hour = time->tm_hour;
+    int day = time->tm_mday;
+    int month = time->tm_mon + 1;
+    int year = time->tm_year + 1900;
+
+    // Update property outputs
+    m_dateStrOut = &dateStr;
+    m_dayStrOut = &dayStr;
+    m_monthStrOut = &monthStr;
+    m_yearStrOut = &yearStr;
+    m_dayIntOut = &day;
+    m_monthIntOut = &month;
+    m_yearIntOut = &year;
+    m_secIntOut = &second;
+    m_minIntOut = &minute;
+    m_hourIntOut = &hour;
+}
+} // namespace Kyber

--- a/Module/Source/Entity/NativeEntityManager.cpp
+++ b/Module/Source/Entity/NativeEntityManager.cpp
@@ -392,7 +392,7 @@ void KyberEntityBase::FireEvent(EventId entityEvent)
 
 void KyberEntityBase::FireEvent(const char* event)
 {
-    KYBER_LOG(Info, "Firing event " << event);
+    KYBER_LOG(Debug, "Firing event " << event);
 
     FireEvent(StringUtils::HashQuick(event));
 }

--- a/Module/Source/Entity/NativeEntityManager.cpp
+++ b/Module/Source/Entity/NativeEntityManager.cpp
@@ -386,14 +386,14 @@ ClassInfoAsset* EntityManager::CreateClassInfoAsset(const KyberTypeInfo& info)
 
 void KyberEntityBase::FireEvent(EventId entityEvent)
 {
-    KYBER_LOG(Info, "Firing event " << entityEvent);
-
     EntityEvent event = entityEvent;
     FullEntityBusInternalFireEventHk(m_nativeEntity->m_entityBus, reinterpret_cast<const DataContainer*>(m_data), &event);
 }
 
 void KyberEntityBase::FireEvent(const char* event)
 {
+    KYBER_LOG(Info, "Firing event " << event);
+
     FireEvent(StringUtils::HashQuick(event));
 }
 


### PR DESCRIPTION
Adds a KyberCurrentTimeEntity and a KyberTimeSplitterEntity for the purpose of getting and using the current time in mods.

Alternatively, you can use a FloatEntity, a CompareFloatEntity, or a MathEntity to do things based on the output of either 2 new entities.

KyberCurrentTimeEntity Outputs:
- Time (Float32)

KyberTimeSplitterEntity Outputs:
- DayInt (Int32)
- MonthInt (Int32)
- YearInt (Int32)
- SecondInt (Int32)
- MinuteInt (Int32)
- HourInt (Int32)