### PR TITLE
[Launcher] fix: replace RadioButton with GestureDetector for fluent_ui breaking change

### DIFF
--- a/Launcher/lib/features/frosty/dialogs/frosty_import_dialog.dart
+++ b/Launcher/lib/features/frosty/dialogs/frosty_import_dialog.dart
@@ -254,43 +254,41 @@ class _FrostyImportDialogState extends State<FrostyImportDialog> {
                                       margin: const EdgeInsets.symmetric(
                                         vertical: 5,
                                       ),
-                                      child: RadioButton(
-                                        style: RadioButtonThemeData(
-                                          checkedDecoration:
-                                              WidgetStateProperty.resolveWith((
-                                                states,
-                                              ) {
-                                                return BoxDecoration(
-                                                  color: Colors.transparent,
-                                                  shape: BoxShape.circle,
-                                                  border: Border.all(
-                                                    color: (states.isHovered)
-                                                        ? kActiveColor
-                                                        : kWhiteColor,
-                                                    width: !states.isDisabled
-                                                        ? states.isHovered &&
-                                                                  !states
-                                                                      .isPressed
-                                                              ? 3.4
-                                                              : 5.0
-                                                        : 4.0,
-                                                  ),
-                                                );
-                                              }),
-                                        ),
-                                        checked: selectedPacks.contains(index),
-                                        onChanged: (value) {
-                                          if (value) {
-                                            selectedPacks.add(index);
-                                          } else {
-                                            selectedPacks.remove(index);
-                                          }
-
-                                          updateModsToImport();
-                                          setState(() {});
+                                      child: GestureDetector(
+                                        onTap: () {
+                                          setState(() {
+                                            if (selectedPacks.contains(index)) {
+                                              selectedPacks.remove(index);
+                                            } else {
+                                              selectedPacks.add(index);
+                                            }
+                                            updateModsToImport();
+                                          });
                                         },
-                                        content: Row(
+                                        child: Row(
                                           children: [
+                                            Container(
+                                              width: 20,
+                                              height: 20,
+                                              decoration: BoxDecoration(
+                                                color: Colors.transparent,
+                                                shape: BoxShape.circle,
+                                                border: Border.all(
+                                                  color:
+                                                      selectedPacks.contains(
+                                                        index,
+                                                      )
+                                                      ? kActiveColor
+                                                      : kWhiteColor,
+                                                  width:
+                                                      selectedPacks.contains(
+                                                        index,
+                                                      )
+                                                      ? 5.0
+                                                      : 2.0,
+                                                ),
+                                              ),
+                                            ),
                                             const SizedBox(width: 10),
                                             Expanded(
                                               child: DefaultTextStyle.merge(


### PR DESCRIPTION
## Problem
Launcher build fails with:
error GC6690633: No named parameter with the name 'checked'

Caused by a breaking change in fluent_ui [fac639b](https://github.com/bdlukaa/fluent_ui/commit/fac639b34462f55370ee5aeeb0c7f017d8f36b62) that reworked the RadioButton API 
to use RadioGroup for state management, removing the `checked` and `onChanged` parameters.

## Solution
The pack selector in frosty_import_dialog.dart uses multi-select behavior which appears to be incompatible with the new RadioGroup/RadioButton API.

Replaced RadioButton with a custom GestureDetector and circular Container that 
replicates the original appearance and behavior while maintaining multi-select functionality.

## Changes
- `Launcher/lib/features/frosty/dialogs/frosty_import_dialog.dart`
  - Replaced `RadioButton` with `GestureDetector` + circular `Container`
  
## Screenshots

<details>
<summary>📸 <b>Before</b> (Click to expand)</summary>
<img src="https://github.com/user-attachments/assets/31a98c38-4b5d-449d-9849-ee0eeb843b70" width="720" alt="Before - unselected state">
</details>

<details>
<summary>📸 <b>After</b> (Click to expand)</summary>
<img src="https://github.com/user-attachments/assets/c01b0172-b16a-4755-9560-49cb20f47acc" width="720" alt="After - selected state">
</details>