### PR TITLE
[CLI] fix: add 'map' category to filterGameplayMods

### DIFF
--- a/CLI/lib/utils/mod_helper.dart
+++ b/CLI/lib/utils/mod_helper.dart
@@ -7,7 +7,7 @@ class ModHelper {
   ModHelper._();
 
   static List<FrostyMod> filterGameplayMods(List<FrostyMod> mods) {
-    return mods.where((mod) => ['gameplay', 'maps'].contains(mod.details.category.toLowerCase())).toList();
+    return mods.where((mod) => ['gameplay', 'maps', 'map'].contains(mod.details.category.toLowerCase())).toList();
   }
 
   static List<FrostyMod> expandMods(List<FrostyMod> mods) {


### PR DESCRIPTION
#### Summary
Adds the missing `map` category to `filterGameplayMods` in the CLI, so map mods are now correctly enforced as required for players joining a server.

- Added `'map'` to the category filter in `CLI/lib/utils/mod_helper.dart`.

#### Verification
Tested locally; verified that the CLI correctly detect a mod with the `map` category from the collection and lists it as required in the server browser.

<details>
<summary>📸 <b>VIEW SCREENSHOT:</b> Map mod correctly listed as required when joining server. (Click to expand)</summary>
<img src="https://github.com/user-attachments/assets/4438ed56-09e4-4e7e-8be0-e3da521fcb9e" width="720" alt="CLI Map Category Fix Screenshot">
</details>
<br>

closes: #46 