### PR TITLE
[Launcher] fix: ensure file creation

### DIFF
--- a/Launcher/lib/core/services/module_version_service.dart
+++ b/Launcher/lib/core/services/module_version_service.dart
@@ -261,6 +261,8 @@ class ModuleVersionService {
       file.deleteSync();
     }
 
+    file.createSync(recursive: true);
+
     final raf = file.openSync(mode: FileMode.write);
 
     try {


### PR DESCRIPTION
Fixes an issue where the launcher would fail to install updates because it wants to open a non-existent file