### PR TITLE
[Launcher] fix: display real mod count for collections

### DIFF
--- a/Launcher/lib/features/mods/widgets/collection_box/collection_box.dart
+++ b/Launcher/lib/features/mods/widgets/collection_box/collection_box.dart
@@ -198,7 +198,7 @@ class _CollectionBoxState extends State<CollectionBox> {
                                     ),
                                   ),
                                   Text(
-                                    '${collection.mods.length} Mods',
+                                    '${collection.getModPaths().length} Mods',
                                     style: const TextStyle(
                                       fontFamily: FontFamily.battlefrontUI,
                                       fontSize: 15,


### PR DESCRIPTION
Now displays the mod count for all mods inside a collection, including mods from Frosty Collections