### PR TITLE
[Launcher] feat: incremental mod updates

### DIFF
--- a/Launcher/lib/core/services/app_settings.dart
+++ b/Launcher/lib/core/services/app_settings.dart
@@ -28,6 +28,12 @@ class General {
 
   set enabledPreloadMods(bool value) => box.put('enabledPreloadMods', value);
 
+  bool get incrementalDownloadsEnabled =>
+      box.get('incrementalDownloadsEnabled', defaultValue: true) as bool;
+
+  set incrementalDownloadsEnabled(bool value) =>
+      box.put('incrementalDownloadsEnabled', value);
+
   String? get currentVersion => box.get('currentVersion') as String?;
 
   set currentVersion(String? value) => box.put('currentVersion', value);

--- a/Launcher/lib/features/download_manager/providers/download_manager_cubit.dart
+++ b/Launcher/lib/features/download_manager/providers/download_manager_cubit.dart
@@ -24,6 +24,8 @@ class DownloadCubit extends Cubit<DownloadState> {
   StreamSubscription<TaskStatusUpdate>? _statusSubscription;
   StreamSubscription<ProgressUpdate>? _extractionProgressSubscription;
 
+  final _callbackTasks = <String, TaskRecord>{};
+
   Future<void> _initialize() async {
     await sl.isReady<DownloadOrchestrator>();
     final orchestrator = _orchestrator ?? sl.get<DownloadOrchestrator>();
@@ -32,7 +34,7 @@ class DownloadCubit extends Cubit<DownloadState> {
       _onProgressUpdate,
     );
     _statusSubscription = orchestrator.statusUpdates.listen(
-      (_) => _loadTasks(),
+      _onStatusUpdate,
     );
     _extractionProgressSubscription = orchestrator.extractionProgressUpdates
         .listen(_onExtractionProgressUpdate);
@@ -40,8 +42,26 @@ class DownloadCubit extends Cubit<DownloadState> {
     await _loadTasks();
   }
 
+  void _onStatusUpdate(TaskStatusUpdate update) {
+    if (update.task is CallbackTask) {
+      if (update.status.isFinalState) {
+        _callbackTasks.remove(update.task.taskId);
+      } else {
+        _callbackTasks[update.task.taskId] = TaskRecord(
+          update.task,
+          update.status,
+          0,
+          -1,
+        );
+      }
+    }
+    _loadTasks();
+  }
+
   Future<void> _loadTasks() async {
     final tasks = await _repository.getActiveTasks();
+
+    tasks.addAll(_callbackTasks.values);
 
     tasks.sort((a, b) {
       if (a.status == TaskStatus.running) {
@@ -61,6 +81,15 @@ class DownloadCubit extends Cubit<DownloadState> {
   }
 
   void _onProgressUpdate(TaskProgressUpdate update) {
+    if (update.task is CallbackTask) {
+      _callbackTasks[update.task.taskId] = TaskRecord(
+        update.task,
+        TaskStatus.running,
+        update.progress,
+        update.expectedFileSize,
+      );
+    }
+
     if (state is DownloadLoaded) {
       final currentState = state as DownloadLoaded;
       emit(currentState.copyWith(progressUpdate: update));

--- a/Launcher/lib/features/download_manager/services/download_orchestrator.dart
+++ b/Launcher/lib/features/download_manager/services/download_orchestrator.dart
@@ -320,6 +320,7 @@ class DownloadOrchestrator with ChangeNotifier {
         final updater = IncrementalUpdater();
         final result = await updater.update(
           downloadUrl: downloadUrl,
+          controller: controller,
           onPhaseChanged: (phase) {
             if (phase != .downloadingMissingMods) {
               controller.updateProgress(1);

--- a/Launcher/lib/features/download_manager/services/download_orchestrator.dart
+++ b/Launcher/lib/features/download_manager/services/download_orchestrator.dart
@@ -196,8 +196,12 @@ class DownloadOrchestrator with ChangeNotifier {
         return false;
       }
 
-      final updater = IncrementalUpdater();
-      if (resolved.filename.endsWith('.zip')) {
+      final isZipFile = extension(resolved.filename) == '.zip';
+      final useIncrementalUpdate =
+          Preferences.general.incrementalDownloadsEnabled;
+
+      if (useIncrementalUpdate && isZipFile) {
+        final updater = IncrementalUpdater();
         final isEligible = await updater.checkEligibility(resolved.url);
         if (isEligible) {
           _logger.info('Using incremental update for ${request.displayName}');

--- a/Launcher/lib/features/download_manager/services/download_orchestrator.dart
+++ b/Launcher/lib/features/download_manager/services/download_orchestrator.dart
@@ -16,6 +16,7 @@ import 'package:kyber_launcher/core/services/notification_service.dart';
 import 'package:kyber_launcher/features/download_manager/models/download_request.dart';
 import 'package:kyber_launcher/features/download_manager/services/download_link_resolver.dart';
 import 'package:kyber_launcher/features/download_manager/services/download_post_processor.dart';
+import 'package:kyber_launcher/features/download_manager/services/incremental_updater.dart';
 import 'package:kyber_launcher/features/download_manager/services/platform/download_platform_integration.dart';
 import 'package:kyber_launcher/features/download_manager/services/platform/windows_taskbar_integration.dart';
 import 'package:kyber_launcher/features/mods/helper/mod_helper.dart';
@@ -195,6 +196,19 @@ class DownloadOrchestrator with ChangeNotifier {
         return false;
       }
 
+      final updater = IncrementalUpdater();
+      if (resolved.filename.endsWith('.zip')) {
+        final isEligible = await updater.checkEligibility(resolved.url);
+        if (isEligible) {
+          _logger.info('Using incremental update for ${request.displayName}');
+
+          return enqueueIncrementalUpdate(
+            resolved.url,
+            request: request,
+          );
+        }
+      }
+
       final result = await FileDownloader().enqueue(
         DownloadTask(
           url: resolved.url,
@@ -295,6 +309,59 @@ class DownloadOrchestrator with ChangeNotifier {
       _logger.warning('Failed to cancel download', e, s);
       return false;
     }
+  }
+
+  Future<bool> enqueueIncrementalUpdate(
+    String downloadUrl, {
+    required DownloadRequest request,
+  }) async {
+    final task = CallbackTask(
+      execute: (controller) async {
+        final updater = IncrementalUpdater();
+        final result = await updater.update(
+          downloadUrl: downloadUrl,
+          onPhaseChanged: (phase) {
+            if (phase != .downloadingMissingMods) {
+              controller.updateProgress(1);
+            } else if (phase == .downloadingMissingMods) {
+              controller.updateProgress(0);
+            }
+          },
+          onProgress: (current, total) {
+            sl.get<DownloadOrchestrator>()._extractionProgressUpdates.add(
+              .new(current, total),
+            );
+          },
+          onDownloadProgress: (bytes, totalBytes) {
+            controller.updateBytesTransferred(
+              bytes,
+              totalBytes,
+              interval: const Duration(milliseconds: 500),
+            );
+          },
+        );
+
+        if (result) {
+          await sl.isReady<ModService>();
+          await sl.get<ModService>().refresh();
+          controller.complete();
+        } else {
+          controller.fail('Failed to apply incremental update');
+        }
+      },
+      displayName: request.displayName,
+      priority: 1,
+      metaData: _encodeMetadata(request.metadata),
+    );
+
+    final enqueued = await FileDownloader().enqueue(task);
+    if (!enqueued) {
+      _logger.warning('Failed to enqueue incremental update');
+      return false;
+    }
+
+    _logger.info('Enqueued incremental update: ${task.displayName}');
+    return true;
   }
 
   Future<void> _taskStatusCallback(TaskStatusUpdate update) async {

--- a/Launcher/lib/features/download_manager/services/incremental_updater.dart
+++ b/Launcher/lib/features/download_manager/services/incremental_updater.dart
@@ -92,10 +92,6 @@ class IncrementalUpdater {
             installed.add(installedMod);
           }
         }
-
-        entries = entries
-            .where((entry) => extension(entry.name).endsWith('.fbmod'))
-            .toList();
       } finally {
         if (d != null) await downloaderDispose(d: d);
         if (tempCollectionPath != null) {
@@ -105,7 +101,7 @@ class IncrementalUpdater {
         }
       }
 
-      if (missing.length == entries.length) {
+      if (missing.length == collection.mods?.length) {
         return false;
       }
 

--- a/Launcher/lib/features/download_manager/services/incremental_updater.dart
+++ b/Launcher/lib/features/download_manager/services/incremental_updater.dart
@@ -1,0 +1,158 @@
+import 'dart:io';
+import 'dart:math';
+
+import 'package:collection/collection.dart';
+import 'package:kyber_collection/kyber_collection.dart';
+import 'package:kyber_launcher/features/mods/services/mod_service.dart';
+import 'package:kyber_launcher/gen/rust/api/downloader.dart';
+import 'package:kyber_launcher/injection_container.dart';
+import 'package:logging/logging.dart';
+import 'package:path/path.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:slugify/slugify.dart';
+
+class IncrementalUpdater {
+  final _logger = Logger('incremental_updater');
+
+  // only a poc for now
+  void updateMod({required String downloadUrl}) async {
+    await sl.isReady<ModService>();
+
+    final tmpDir = await getTemporaryDirectory();
+
+    var entries = <ZipEntryInfo>[];
+    final installed = <FrostyMod>[];
+    final missing = <(String, String)>[];
+    FrostyMod? collection;
+    ZipEntryInfo? collectionEntry;
+    late DownloaderHandle d;
+
+    try {
+      d = await downloaderCreate(
+        id: '0',
+        zipUrl: downloadUrl,
+        outputDir: tmpDir.path,
+      );
+      entries = await downloaderListEntries(d: d);
+
+      collectionEntry = entries.firstWhereOrNull(
+            (entry) => extension(entry.name) == '.fbcollection',
+      );
+
+      if (collectionEntry == null) {
+        print('No collection found in the mod package');
+        return;
+      }
+
+      await downloaderDownloadEntryByName(
+        d: d,
+        entryName: collectionEntry.name,
+      );
+
+      final file = File(join(tmpDir.path, collectionEntry.name)).openSync();
+      collection = FrostyCollectionReader(
+        file,
+        collectionEntry.name,
+      ).readMod();
+      if (collection == null) {
+        return;
+      }
+
+      final installedMods = sl.get<ModService>().mods;
+      for (final mod in collection.mods!) {
+        final index = collection.mods!.indexOf(mod);
+        final modVersion = collection.modVersions![index];
+        final installedMod = installedMods
+            .where((m) => basename(m.filename) == mod)
+            .where((m) => m.details.version == modVersion)
+            .firstOrNull;
+
+        if (installedMod == null) {
+          missing.add((mod, modVersion));
+        } else {
+          installed.add(installedMod);
+        }
+      }
+
+      entries = entries
+          .where((entry) => extension(entry.name).endsWith('.fbmod'))
+          .toList();
+    } finally {
+      await downloaderDispose(d: d);
+    }
+
+    if (missing.length == entries.length - 1) {
+      print('All mods are missing');
+      return;
+    }
+
+    final random = String.fromCharCodes(
+      List.generate(8, (index) => Random().nextInt(26) + 97),
+    );
+
+    final newDir = join(
+      ModService.getBasePath(),
+      slugify(
+        '${collection.details.name} ${collection.details.version} $random',
+      ),
+    );
+
+    d = await downloaderCreate(
+      id: '1',
+      zipUrl: downloadUrl,
+      outputDir: join(ModService.getBasePath(), ''),
+    );
+
+    print(
+      'Missing mods for collection ${collection.details.name} (${collection.details.version}): ${missing.length}',
+    );
+
+    final totalZipSize = entries.fold<int>(
+      0,
+          (previousValue, element) => previousValue + element.compressedSize,
+    );
+    final missingSize = entries
+        .where(
+          (entry) => missing.where((mod) => mod.$1 == entry.name).isNotEmpty,
+    )
+        .fold<int>(
+      0,
+          (previousValue, element) => previousValue + element.compressedSize,
+    );
+    print(
+      'Total zip size: ${totalZipSize / 1024 / 1024 / 1024} GB, missing mods size: ${missingSize / 1024 / 1024 / 1024} GB',
+    );
+
+    print('Copying existing mods to $newDir');
+    await Directory(newDir).create(recursive: true);
+
+    for (final mod in installed) {
+      final newPath = join(newDir, basename(mod.filename));
+      print('Copying ${basename(mod.filename)} to $newPath');
+      await File(join(ModService.getBasePath(), mod.filename)).copy(newPath);
+    }
+
+    try {
+      for (final mod in missing) {
+        print('Downloading missing mod ${mod.$1}');
+        await downloaderDownloadEntryByName(d: d, entryName: mod.$1);
+        final downloadedPath = join(
+          ModService.getBasePath(),
+          basename(mod.$1),
+        );
+        final newPath = join(newDir, basename(mod.$1));
+        await File(downloadedPath).rename(newPath);
+      }
+    } finally {
+      await downloaderDispose(d: d);
+    }
+
+    final collectionFilePath = join(newDir, basename(collectionEntry!.name));
+    print('Copying collection file to $collectionFilePath');
+    await File(
+      join(tmpDir.path, collectionEntry.name),
+    ).copy(collectionFilePath);
+
+    print('All mods for collection are now in $newDir');
+  }
+}

--- a/Launcher/lib/features/download_manager/services/incremental_updater.dart
+++ b/Launcher/lib/features/download_manager/services/incremental_updater.dart
@@ -41,7 +41,9 @@ class IncrementalUpdater {
 
       DownloaderHandle? d;
       try {
-        _logger.fine('Checking incremental update eligibility for $downloadUrl');
+        _logger.fine(
+          'Checking incremental update eligibility for $downloadUrl',
+        );
 
         d = await downloaderCreate(
           id: 'check-${DateTime.now().millisecondsSinceEpoch}',
@@ -130,7 +132,17 @@ class IncrementalUpdater {
 
     await sl.isReady<ModService>();
 
-    final tmpDir = await getTemporaryDirectory();
+    final rndStr = String.fromCharCodes(
+      List.generate(8, (index) => Random().nextInt(26) + 97),
+    );
+    final tmpDir = Directory(join(ModService.getBasePath(), '_tmp_$rndStr'));
+
+    if (tmpDir.existsSync()) {
+      await tmpDir.delete(recursive: true);
+    }
+
+    await tmpDir.create(recursive: true);
+
     String? newDir;
 
     try {
@@ -244,7 +256,7 @@ class IncrementalUpdater {
       d = await downloaderCreate(
         id: '1',
         zipUrl: downloadUrl,
-        outputDir: join(ModService.getBasePath(), ''),
+        outputDir: tmpDir.path,
       );
 
       final total = missingSize;
@@ -266,14 +278,18 @@ class IncrementalUpdater {
           );
           final streamSink = RustStreamSink<int>();
 
-          // TODO: use frb cancel token to allow cancelling mid-download
           final future = downloaderDownloadEntryByName(
             d: d,
             entryName: mod.$1,
             progress: streamSink,
           );
 
-          streamSink.stream.listen((bytes) {
+          streamSink.stream.listen((bytes) async {
+            if (controller?.isCancelled ?? false) {
+              await downloaderCancel(d: d);
+              return;
+            }
+
             current += bytes;
             onDownloadProgress?.call(current, total);
           });
@@ -281,18 +297,25 @@ class IncrementalUpdater {
           await future;
 
           final downloadedPath = join(
-            ModService.getBasePath(),
+            tmpDir.path,
             basename(mod.$1),
           );
           final destPath = join(newDir, basename(mod.$1));
           await File(downloadedPath).rename(destPath);
+        }
+      } catch (e, s) {
+        if (e == 'cancelled') {
+          throw const CancelledException();
+        } else {
+          _logger.severe('Failed to download missing mods', e, s);
+          rethrow;
         }
       } finally {
         await downloaderDispose(d: d);
       }
 
       onDownloadProgress?.call(total, total);
-      
+
       _logger.info('All missing mods downloaded, copying existing mods');
 
       for (var i = 0; i < installed.length; i++) {
@@ -319,10 +342,6 @@ class IncrementalUpdater {
         join(tmpDir.path, collectionEntry.name),
       );
       await tempCollectionFile.copy(collectionFilePath);
-
-      try {
-        await tempCollectionFile.delete();
-      } catch (_) {}
 
       return true;
     } on CancelledException {
@@ -353,6 +372,10 @@ class IncrementalUpdater {
       }
 
       return false;
+    } finally {
+      try {
+        tmpDir.delete(recursive: true);
+      } catch (_) {}
     }
   }
 

--- a/Launcher/lib/features/download_manager/services/incremental_updater.dart
+++ b/Launcher/lib/features/download_manager/services/incremental_updater.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:collection/collection.dart';
+import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 import 'package:kyber_collection/kyber_collection.dart';
 import 'package:kyber_launcher/features/mods/services/mod_service.dart';
 import 'package:kyber_launcher/gen/rust/api/downloader.dart';
@@ -11,148 +12,342 @@ import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:slugify/slugify.dart';
 
+const _kAllowedHosts = [
+  'kyber.gg',
+  'nexusmods.com',
+];
+
 class IncrementalUpdater {
   final _logger = Logger('incremental_updater');
 
-  // only a poc for now
-  void updateMod({required String downloadUrl}) async {
+  Future<bool> checkEligibility(String downloadUrl) async {
+    final uri = Uri.parse(downloadUrl);
+
+    if (!_kAllowedHosts.any((host) => uri.host.endsWith(host))) {
+      return false;
+    }
+
     await sl.isReady<ModService>();
 
     final tmpDir = await getTemporaryDirectory();
 
-    var entries = <ZipEntryInfo>[];
-    final installed = <FrostyMod>[];
-    final missing = <(String, String)>[];
-    FrostyMod? collection;
-    ZipEntryInfo? collectionEntry;
-    late DownloaderHandle d;
-
     try {
-      d = await downloaderCreate(
-        id: '0',
-        zipUrl: downloadUrl,
-        outputDir: tmpDir.path,
-      );
-      entries = await downloaderListEntries(d: d);
+      var entries = <ZipEntryInfo>[];
+      final installed = <FrostyMod>[];
+      final missing = <(String, String)>[];
+      FrostyMod? collection;
+      String? tempCollectionPath;
 
-      collectionEntry = entries.firstWhereOrNull(
-            (entry) => extension(entry.name) == '.fbcollection',
-      );
+      DownloaderHandle? d;
+      try {
+        d = await downloaderCreate(
+          id: 'check-${DateTime.now().millisecondsSinceEpoch}',
+          zipUrl: downloadUrl,
+          outputDir: tmpDir.path,
+        );
+        entries = await downloaderListEntries(d: d);
 
-      if (collectionEntry == null) {
-        print('No collection found in the mod package');
-        return;
-      }
+        final collectionEntry = entries.firstWhereOrNull(
+          (entry) => extension(entry.name) == '.fbcollection',
+        );
 
-      await downloaderDownloadEntryByName(
-        d: d,
-        entryName: collectionEntry.name,
-      );
+        if (collectionEntry == null) {
+          return false;
+        }
 
-      final file = File(join(tmpDir.path, collectionEntry.name)).openSync();
-      collection = FrostyCollectionReader(
-        file,
-        collectionEntry.name,
-      ).readMod();
-      if (collection == null) {
-        return;
-      }
+        await downloaderDownloadEntryByName(
+          d: d,
+          entryName: collectionEntry.name,
+        );
 
-      final installedMods = sl.get<ModService>().mods;
-      for (final mod in collection.mods!) {
-        final index = collection.mods!.indexOf(mod);
-        final modVersion = collection.modVersions![index];
-        final installedMod = installedMods
-            .where((m) => basename(m.filename) == mod)
-            .where((m) => m.details.version == modVersion)
-            .firstOrNull;
+        tempCollectionPath = join(tmpDir.path, collectionEntry.name);
+        final file = File(tempCollectionPath).openSync();
+        collection = FrostyCollectionReader(
+          file,
+          collectionEntry.name,
+        ).readMod();
 
-        if (installedMod == null) {
-          missing.add((mod, modVersion));
-        } else {
-          installed.add(installedMod);
+        if (collection == null) {
+          return false;
+        }
+
+        final installedMods = sl.get<ModService>().mods;
+        for (final mod in collection.mods!) {
+          final index = collection.mods!.indexOf(mod);
+          final modVersion = collection.modVersions![index];
+          final installedMod = installedMods
+              .where((m) => basename(m.filename) == mod)
+              .where((m) => m.details.version == modVersion)
+              .firstOrNull;
+
+          if (installedMod == null) {
+            missing.add((mod, modVersion));
+          } else {
+            installed.add(installedMod);
+          }
+        }
+
+        entries = entries
+            .where((entry) => extension(entry.name).endsWith('.fbmod'))
+            .toList();
+      } finally {
+        if (d != null) await downloaderDispose(d: d);
+        if (tempCollectionPath != null) {
+          try {
+            await File(tempCollectionPath).delete();
+          } catch (_) {}
         }
       }
 
-      entries = entries
-          .where((entry) => extension(entry.name).endsWith('.fbmod'))
-          .toList();
-    } finally {
-      await downloaderDispose(d: d);
+      if (missing.length == entries.length) {
+        return false;
+      }
+
+      return true;
+    } catch (e, s) {
+      _logger.warning('Eligibility check failed', e, s);
+      return false;
+    }
+  }
+
+  Future<bool> update({
+    required String downloadUrl,
+    void Function(UpdatePhase phase)? onPhaseChanged,
+    void Function(int current, int total)? onProgress,
+    void Function(int bytesDownloaded, int totalBytes)? onDownloadProgress,
+  }) async {
+    final uri = Uri.parse(downloadUrl);
+
+    if (!_kAllowedHosts.any((host) => uri.host.endsWith(host))) {
+      _logger.warning(
+        'Rejected download from unallowed domain: ${uri.host}',
+      );
+      return false;
     }
 
-    if (missing.length == entries.length - 1) {
-      print('All mods are missing');
-      return;
-    }
+    await sl.isReady<ModService>();
 
-    final random = String.fromCharCodes(
-      List.generate(8, (index) => Random().nextInt(26) + 97),
-    );
-
-    final newDir = join(
-      ModService.getBasePath(),
-      slugify(
-        '${collection.details.name} ${collection.details.version} $random',
-      ),
-    );
-
-    d = await downloaderCreate(
-      id: '1',
-      zipUrl: downloadUrl,
-      outputDir: join(ModService.getBasePath(), ''),
-    );
-
-    print(
-      'Missing mods for collection ${collection.details.name} (${collection.details.version}): ${missing.length}',
-    );
-
-    final totalZipSize = entries.fold<int>(
-      0,
-          (previousValue, element) => previousValue + element.compressedSize,
-    );
-    final missingSize = entries
-        .where(
-          (entry) => missing.where((mod) => mod.$1 == entry.name).isNotEmpty,
-    )
-        .fold<int>(
-      0,
-          (previousValue, element) => previousValue + element.compressedSize,
-    );
-    print(
-      'Total zip size: ${totalZipSize / 1024 / 1024 / 1024} GB, missing mods size: ${missingSize / 1024 / 1024 / 1024} GB',
-    );
-
-    print('Copying existing mods to $newDir');
-    await Directory(newDir).create(recursive: true);
-
-    for (final mod in installed) {
-      final newPath = join(newDir, basename(mod.filename));
-      print('Copying ${basename(mod.filename)} to $newPath');
-      await File(join(ModService.getBasePath(), mod.filename)).copy(newPath);
-    }
+    final tmpDir = await getTemporaryDirectory();
+    String? newDir;
 
     try {
-      for (final mod in missing) {
-        print('Downloading missing mod ${mod.$1}');
-        await downloaderDownloadEntryByName(d: d, entryName: mod.$1);
-        final downloadedPath = join(
-          ModService.getBasePath(),
-          basename(mod.$1),
+      onPhaseChanged?.call(.fetchingEntries);
+
+      onProgress?.call(1, 1);
+
+      var entries = <ZipEntryInfo>[];
+      final installed = <FrostyMod>[];
+      final missing = <(String, String)>[];
+      FrostyMod? collection;
+      ZipEntryInfo? collectionEntry;
+
+      _logger.info('Fetching mod collection entries from $downloadUrl');
+
+      late DownloaderHandle d;
+      try {
+        d = await downloaderCreate(
+          id: '0',
+          zipUrl: downloadUrl,
+          outputDir: tmpDir.path,
         );
-        final newPath = join(newDir, basename(mod.$1));
-        await File(downloadedPath).rename(newPath);
+        entries = await downloaderListEntries(d: d);
+
+        collectionEntry = entries.firstWhereOrNull(
+          (entry) => extension(entry.name) == '.fbcollection',
+        );
+
+        if (collectionEntry == null) {
+          _logger.warning('No .fbcollection found in the mod package');
+          return false;
+        }
+
+        onPhaseChanged?.call(.parsingCollection);
+
+        await downloaderDownloadEntryByName(
+          d: d,
+          entryName: collectionEntry.name,
+        );
+
+        final file = File(join(tmpDir.path, collectionEntry.name)).openSync();
+        collection = FrostyCollectionReader(
+          file,
+          collectionEntry.name,
+        ).readMod();
+
+        if (collection == null) {
+          _logger.warning('Failed to parse collection manifest');
+          return false;
+        }
+
+        onPhaseChanged?.call(.comparingMods);
+
+        final installedMods = sl.get<ModService>().mods;
+        for (final mod in collection.mods!) {
+          final index = collection.mods!.indexOf(mod);
+          final modVersion = collection.modVersions![index];
+          final installedMod = installedMods
+              .where((m) => basename(m.filename) == mod)
+              .where((m) => m.details.version == modVersion)
+              .firstOrNull;
+
+          if (installedMod == null) {
+            missing.add((mod, modVersion));
+          } else {
+            installed.add(installedMod);
+          }
+        }
+
+        entries = entries
+            .where((entry) => extension(entry.name).endsWith('.fbmod'))
+            .toList();
+      } finally {
+        await downloaderDispose(d: d);
       }
-    } finally {
-      await downloaderDispose(d: d);
+
+      if (missing.length == entries.length) {
+        _logger.info('All mods are missing, incremental update not beneficial');
+        return false;
+      }
+
+      final missingSize = entries
+          .where(
+            (entry) => missing.where((mod) => mod.$1 == entry.name).isNotEmpty,
+          )
+          .fold<int>(0, (sum, e) => sum + e.compressedSize);
+
+      onPhaseChanged?.call(.copyingExistingMods);
+
+      final random = String.fromCharCodes(
+        List.generate(8, (index) => Random().nextInt(26) + 97),
+      );
+
+      newDir = join(
+        ModService.getBasePath(),
+        slugify(
+          '${collection.details.name} ${collection.details.version} $random',
+        ),
+      );
+
+      _logger.info('Creating collection in $newDir');
+      await Directory(newDir).create(recursive: true);
+
+      onPhaseChanged?.call(.downloadingMissingMods);
+
+      d = await downloaderCreate(
+        id: '1',
+        zipUrl: downloadUrl,
+        outputDir: join(ModService.getBasePath(), ''),
+      );
+
+      final total = missingSize;
+      var current = 0;
+
+      _logger.info(
+        'Starting download of ${missing.length} missing mods (${_formatBytes(total)})',
+      );
+
+      try {
+        for (var i = 0; i < missing.length; i++) {
+          final mod = missing[i];
+          final entryInfo = entries.firstWhereOrNull(
+            (e) => e.name == mod.$1,
+          );
+          _logger.fine(
+            'Downloading ${basename(mod.$1)} (${_formatBytes(entryInfo?.compressedSize ?? 0)})',
+          );
+          final streamSink = RustStreamSink<int>();
+
+          final future = downloaderDownloadEntryByName(
+            d: d,
+            entryName: mod.$1,
+            progress: streamSink,
+          );
+
+          streamSink.stream.listen((bytes) {
+            current += bytes;
+            onDownloadProgress?.call(current, total);
+          });
+
+          await future;
+
+          final downloadedPath = join(
+            ModService.getBasePath(),
+            basename(mod.$1),
+          );
+          final destPath = join(newDir, basename(mod.$1));
+          await File(downloadedPath).rename(destPath);
+        }
+      } finally {
+        await downloaderDispose(d: d);
+      }
+
+      onDownloadProgress?.call(total, total);
+      
+      _logger.info('All missing mods downloaded, copying existing mods');
+
+      for (var i = 0; i < installed.length; i++) {
+        final mod = installed[i];
+        onProgress?.call(i + 1, installed.length);
+
+        final newPath = join(newDir, basename(mod.filename));
+        _logger.fine('Copying ${basename(mod.filename)}');
+        await File(join(ModService.getBasePath(), mod.filename)).copy(newPath);
+      }
+
+      onPhaseChanged?.call(.finalizing);
+
+      onProgress?.call(1, 1);
+
+      final collectionFilePath = join(
+        newDir,
+        basename(collectionEntry.name),
+      );
+      _logger.fine('Copying collection manifest to $collectionFilePath');
+
+      final tempCollectionFile = File(
+        join(tmpDir.path, collectionEntry.name),
+      );
+      await tempCollectionFile.copy(collectionFilePath);
+
+      try {
+        await tempCollectionFile.delete();
+      } catch (_) {}
+
+      return true;
+    } catch (e, s) {
+      _logger.severe('Incremental update failed', e, s);
+
+      if (newDir != null) {
+        try {
+          await Directory(newDir).delete(recursive: true);
+        } catch (_) {
+          _logger.warning(
+            'Failed to clean up partial output directory: $newDir',
+          );
+        }
+      }
+
+      return false;
     }
-
-    final collectionFilePath = join(newDir, basename(collectionEntry!.name));
-    print('Copying collection file to $collectionFilePath');
-    await File(
-      join(tmpDir.path, collectionEntry.name),
-    ).copy(collectionFilePath);
-
-    print('All mods for collection are now in $newDir');
   }
+
+  static String _formatBytes(int bytes) {
+    if (bytes < 1024) return '$bytes B';
+    if (bytes < 1024 * 1024) {
+      return '${(bytes / 1024).toStringAsFixed(1)} KB';
+    }
+    if (bytes < 1024 * 1024 * 1024) {
+      return '${(bytes / 1024 / 1024).toStringAsFixed(1)} MB';
+    }
+    return '${(bytes / 1024 / 1024 / 1024).toStringAsFixed(2)} GB';
+  }
+}
+
+enum UpdatePhase {
+  fetchingEntries,
+  parsingCollection,
+  comparingMods,
+  copyingExistingMods,
+  downloadingMissingMods,
+  finalizing,
 }

--- a/Launcher/lib/features/download_manager/services/incremental_updater.dart
+++ b/Launcher/lib/features/download_manager/services/incremental_updater.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'dart:math';
 
+import 'package:background_downloader/background_downloader.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 import 'package:kyber_collection/kyber_collection.dart';
@@ -40,11 +41,15 @@ class IncrementalUpdater {
 
       DownloaderHandle? d;
       try {
+        _logger.fine('Checking incremental update eligibility for $downloadUrl');
+
         d = await downloaderCreate(
           id: 'check-${DateTime.now().millisecondsSinceEpoch}',
           zipUrl: downloadUrl,
           outputDir: tmpDir.path,
         );
+
+        _logger.fine('Fetching mod collection entries for eligibility check');
         entries = await downloaderListEntries(d: d);
 
         final collectionEntry = entries.firstWhereOrNull(
@@ -55,6 +60,7 @@ class IncrementalUpdater {
           return false;
         }
 
+        _logger.fine('Downloading collection manifest for eligibility check');
         await downloaderDownloadEntryByName(
           d: d,
           entryName: collectionEntry.name,
@@ -115,6 +121,7 @@ class IncrementalUpdater {
     void Function(UpdatePhase phase)? onPhaseChanged,
     void Function(int current, int total)? onProgress,
     void Function(int bytesDownloaded, int totalBytes)? onDownloadProgress,
+    CallbackTaskController? controller,
   }) async {
     final uri = Uri.parse(downloadUrl);
 
@@ -131,6 +138,7 @@ class IncrementalUpdater {
     String? newDir;
 
     try {
+      controller?.throwIfCancelled();
       onPhaseChanged?.call(.fetchingEntries);
 
       onProgress?.call(1, 1);
@@ -161,6 +169,7 @@ class IncrementalUpdater {
           return false;
         }
 
+        controller?.throwIfCancelled();
         onPhaseChanged?.call(.parsingCollection);
 
         await downloaderDownloadEntryByName(
@@ -179,6 +188,7 @@ class IncrementalUpdater {
           return false;
         }
 
+        controller?.throwIfCancelled();
         onPhaseChanged?.call(.comparingMods);
 
         final installedMods = sl.get<ModService>().mods;
@@ -215,6 +225,7 @@ class IncrementalUpdater {
           )
           .fold<int>(0, (sum, e) => sum + e.compressedSize);
 
+      controller?.throwIfCancelled();
       onPhaseChanged?.call(.copyingExistingMods);
 
       final random = String.fromCharCodes(
@@ -231,6 +242,7 @@ class IncrementalUpdater {
       _logger.info('Creating collection in $newDir');
       await Directory(newDir).create(recursive: true);
 
+      controller?.throwIfCancelled();
       onPhaseChanged?.call(.downloadingMissingMods);
 
       d = await downloaderCreate(
@@ -248,6 +260,7 @@ class IncrementalUpdater {
 
       try {
         for (var i = 0; i < missing.length; i++) {
+          controller?.throwIfCancelled();
           final mod = missing[i];
           final entryInfo = entries.firstWhereOrNull(
             (e) => e.name == mod.$1,
@@ -257,6 +270,7 @@ class IncrementalUpdater {
           );
           final streamSink = RustStreamSink<int>();
 
+          // TODO: use frb cancel token to allow cancelling mid-download
           final future = downloaderDownloadEntryByName(
             d: d,
             entryName: mod.$1,
@@ -286,6 +300,7 @@ class IncrementalUpdater {
       _logger.info('All missing mods downloaded, copying existing mods');
 
       for (var i = 0; i < installed.length; i++) {
+        controller?.throwIfCancelled();
         final mod = installed[i];
         onProgress?.call(i + 1, installed.length);
 
@@ -314,6 +329,20 @@ class IncrementalUpdater {
       } catch (_) {}
 
       return true;
+    } on CancelledException {
+      _logger.info('Incremental update cancelled');
+
+      if (newDir != null) {
+        try {
+          await Directory(newDir).delete(recursive: true);
+        } catch (_) {
+          _logger.warning(
+            'Failed to clean up partial output directory: $newDir',
+          );
+        }
+      }
+
+      rethrow;
     } catch (e, s) {
       _logger.severe('Incremental update failed', e, s);
 

--- a/Launcher/lib/features/maxima/widgets/maxima_navigation_bar_widget.dart
+++ b/Launcher/lib/features/maxima/widgets/maxima_navigation_bar_widget.dart
@@ -1,3 +1,4 @@
+import 'package:background_downloader/background_downloader.dart';
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:kyber_launcher/core/config/colors.dart';
@@ -388,10 +389,26 @@ class _DownloadItem extends StatelessWidget {
                                     ? (extractingProgress.extracted /
                                           extractingProgress.total)
                                     : 1.0;
-                                displayText =
-                                    'EXTRACTING FILE (${extractingProgress?.extracted ?? '?'}/${extractingProgress?.total ?? '?'})';
+
+                                final extracted = extractingProgress.extracted;
+                                final total = extractingProgress.total;
+                                if (extractingProgress.total == 1) {
+                                  displayText = 'FINALIZING COLLECTION';
+                                } else {
+                                  if (currentDownload.task is CallbackTask) {
+                                    displayText =
+                                        'COPYING FILES ($extracted/$total)';
+                                  } else {
+                                    displayText =
+                                        'EXTRACTING FILE ($extracted/$total)';
+                                  }
+                                }
                               } else if (xProgress >= 1) {
-                                displayText = 'EXTRACTING FILE';
+                                if (currentDownload.task is CallbackTask) {
+                                  displayText = 'INITIALIZING DOWNLOAD';
+                                } else {
+                                  displayText = 'EXTRACTING FILE';
+                                }
                               } else {
                                 displayText =
                                     'DOWNLOADING (${(progress * 100).toInt()}% ${formatBytes((expectedFileSize * progress).toInt(), 1)}/${formatBytes(expectedFileSize, 1)})';

--- a/Launcher/lib/features/settings/screens/pages/mod_support.dart
+++ b/Launcher/lib/features/settings/screens/pages/mod_support.dart
@@ -17,7 +17,7 @@ class ModSupport extends StatelessWidget {
         const SettingsHeader(title: 'MODS'),
         HiveListener(
           box: box,
-          keys: ['enabledPreloadMods'],
+          keys: ['enabledPreloadMods', 'incrementalDownloadsEnabled'],
           builder: (_) => KyberTable(
             items: [
               KyberTableItem.button(
@@ -41,6 +41,13 @@ class ModSupport extends StatelessWidget {
                 value: Preferences.general.enabledPreloadMods,
                 onChange: (bool value) {
                   Preferences.general.enabledPreloadMods = value;
+                },
+              ),
+              KyberTableItem.switchButton(
+                title: 'Incremental Mod Downloads',
+                value: Preferences.general.incrementalDownloadsEnabled,
+                onChange: (bool value) {
+                  Preferences.general.incrementalDownloadsEnabled = value;
                 },
               ),
             ],

--- a/Launcher/pubspec.yaml
+++ b/Launcher/pubspec.yaml
@@ -112,7 +112,7 @@ dependencies:
   window_to_front: ^0.0.3
   windows_taskbar: ^1.1.2
   win32_registry: ^2.1.0
-  flutter_rust_bridge: any
+  flutter_rust_bridge: 2.11.1
   pool: ^1.5.2
   native_toolchain_rust: ^1.0.0+1
   hive: ^2.2.3

--- a/Launcher/rust/Cargo.toml
+++ b/Launcher/rust/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib", "staticlib"]
 [dependencies]
 flutter_rust_bridge = { version = "=2.11.1", default-features = false, features = ["anyhow", "user-utils", "dart-opaque", "backtrace", "thread-pool", "rust-async", "uuid"] }
 tokio = { version = "1.36.0", features = ["full", "rt", "rt-multi-thread", "time", "net"] }
+tokio-util = "0.7"
 log = "0.4.20"
 maxima-lib = { path = "../../ThirdParty/Maxima/maxima-lib" }
 lazy_static = "1.4.0"

--- a/Launcher/rust/src/api/downloader.rs
+++ b/Launcher/rust/src/api/downloader.rs
@@ -1,0 +1,111 @@
+use flutter_rust_bridge::frb;
+
+use crate::frb_generated::{RustAutoOpaque, StreamSink};
+
+use maxima::content::{
+    downloader::ZipDownloader,
+    zip::{CompressionType, ZipFileEntry},
+};
+
+#[frb(opaque)]
+pub struct DownloaderHandle(ZipDownloader);
+
+#[frb(non_opaque)]
+#[derive(Clone, Debug)]
+pub struct ZipEntryInfo {
+    pub name: String,
+    pub compressed_size: i64,
+    pub uncompressed_size: i64,
+    pub compression: String,
+    pub data_offset: i64,
+    pub crc32: u32,
+}
+
+fn entry_to_info(e: &ZipFileEntry) -> ZipEntryInfo {
+    ZipEntryInfo {
+        name: e.name().to_string(),
+        compressed_size: *e.compressed_size(),
+        uncompressed_size: *e.uncompressed_size(),
+        compression: match e.compression_type() {
+            CompressionType::None => "none".to_string(),
+            CompressionType::Deflate => "deflate".to_string(),
+            other => format!("{other:?}"),
+        },
+        data_offset: *e.data_offset(),
+        crc32: *e.crc32(),
+    }
+}
+
+pub async fn downloader_create(
+    id: String,
+    zip_url: String,
+    output_dir: String,
+) -> Result<RustAutoOpaque<DownloaderHandle>, String> {
+    let dl = ZipDownloader::new(&id, &zip_url, output_dir)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok(RustAutoOpaque::new(DownloaderHandle(dl)))
+}
+
+pub async fn downloader_get_id(d: RustAutoOpaque<DownloaderHandle>) -> String {
+    d.read().await.0.id().to_string()
+}
+
+pub async fn downloader_list_entries(d: RustAutoOpaque<DownloaderHandle>) -> Vec<ZipEntryInfo> {
+    d.read().await.0.manifest()
+        .entries()
+        .iter()
+        .map(entry_to_info)
+        .collect()
+}
+
+fn find_entry<'a>(d: &'a ZipDownloader, entry_name: &str) -> Result<&'a ZipFileEntry, String> {
+    d.manifest()
+        .entries()
+        .iter()
+        .find(|e| e.name() == entry_name)
+        .ok_or_else(|| format!("Zip entry not found: {entry_name}"))
+}
+
+pub async fn downloader_download_entry_by_name(
+    d: RustAutoOpaque<DownloaderHandle>,
+    entry_name: String,
+    progress: Option<StreamSink<i32>>,
+) -> Result<i32, String> {
+    let inner: &ZipDownloader = &d.read().await.0;
+
+    let entry = find_entry(inner, &entry_name)?;
+
+    let callback = progress.map(|sink| {
+        Box::new(move |n: usize| {
+            let _ = sink.add(n as i32);
+        }) as Box<dyn Fn(usize) + Send + Sync>
+    });
+
+    let written = inner
+        .download_single_file(entry, callback)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok(written as i32)
+}
+
+pub async fn downloader_read_entry_bytes(
+    d: RustAutoOpaque<DownloaderHandle>,
+    entry_name: String,
+    length: i64,
+) -> Result<Vec<u8>, String> {
+    let inner: &ZipDownloader = &d.read().await.0;
+    let entry = find_entry(inner, &entry_name)?;
+
+    let bytes = inner
+        .read_zip_entry_bytes(entry, length as u64)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok(bytes.to_vec())
+}
+
+pub fn downloader_dispose(_d: RustAutoOpaque<DownloaderHandle>) {
+}

--- a/Launcher/rust/src/api/downloader.rs
+++ b/Launcher/rust/src/api/downloader.rs
@@ -1,4 +1,7 @@
+use std::sync::Mutex;
+
 use flutter_rust_bridge::frb;
+use tokio_util::sync::CancellationToken;
 
 use crate::frb_generated::{RustAutoOpaque, StreamSink};
 
@@ -8,7 +11,10 @@ use maxima::content::{
 };
 
 #[frb(opaque)]
-pub struct DownloaderHandle(ZipDownloader);
+pub struct DownloaderHandle {
+    inner: ZipDownloader,
+    cancel: Mutex<CancellationToken>,
+}
 
 #[frb(non_opaque)]
 #[derive(Clone, Debug)]
@@ -45,15 +51,18 @@ pub async fn downloader_create(
         .await
         .map_err(|e| e.to_string())?;
 
-    Ok(RustAutoOpaque::new(DownloaderHandle(dl)))
+    Ok(RustAutoOpaque::new(DownloaderHandle {
+        inner: dl,
+        cancel: Mutex::new(CancellationToken::new()),
+    }))
 }
 
 pub async fn downloader_get_id(d: RustAutoOpaque<DownloaderHandle>) -> String {
-    d.read().await.0.id().to_string()
+    d.read().await.inner.id().to_string()
 }
 
 pub async fn downloader_list_entries(d: RustAutoOpaque<DownloaderHandle>) -> Vec<ZipEntryInfo> {
-    d.read().await.0.manifest()
+    d.read().await.inner.manifest()
         .entries()
         .iter()
         .map(entry_to_info)
@@ -73,9 +82,16 @@ pub async fn downloader_download_entry_by_name(
     entry_name: String,
     progress: Option<StreamSink<i32>>,
 ) -> Result<i32, String> {
-    let inner: &ZipDownloader = &d.read().await.0;
+    let handle = d.read().await;
+    let inner: &ZipDownloader = &handle.inner;
 
     let entry = find_entry(inner, &entry_name)?;
+
+    let token = {
+        let mut guard = handle.cancel.lock().unwrap();
+        *guard = CancellationToken::new();
+        guard.clone()
+    };
 
     let callback = progress.map(|sink| {
         Box::new(move |n: usize| {
@@ -83,12 +99,19 @@ pub async fn downloader_download_entry_by_name(
         }) as Box<dyn Fn(usize) + Send + Sync>
     });
 
-    let written = inner
-        .download_single_file(entry, callback)
-        .await
-        .map_err(|e| e.to_string())?;
+    tokio::select! {
+        res = inner.download_single_file(entry, callback) => {
+            let written = res.map_err(|e| e.to_string())?;
+            Ok(written as i32)
+        }
+        _ = token.cancelled() => {
+            Err("cancelled".to_string())
+        }
+    }
+}
 
-    Ok(written as i32)
+pub async fn downloader_cancel(d: RustAutoOpaque<DownloaderHandle>) {
+    d.read().await.cancel.lock().unwrap().cancel();
 }
 
 pub async fn downloader_read_entry_bytes(
@@ -96,7 +119,7 @@ pub async fn downloader_read_entry_bytes(
     entry_name: String,
     length: i64,
 ) -> Result<Vec<u8>, String> {
-    let inner: &ZipDownloader = &d.read().await.0;
+    let inner: &ZipDownloader = &d.read().await.inner;
     let entry = find_entry(inner, &entry_name)?;
 
     let bytes = inner

--- a/Launcher/rust/src/api/mod.rs
+++ b/Launcher/rust/src/api/mod.rs
@@ -2,3 +2,4 @@ use std::str::FromStr;
 
 pub mod maxima;
 pub mod archive;
+pub mod downloader;

--- a/Packages/kyber_collection/lib/src/frosty/frosty_collection_reader.dart
+++ b/Packages/kyber_collection/lib/src/frosty/frosty_collection_reader.dart
@@ -65,6 +65,7 @@ class FrostyCollectionReader extends FileByteReader {
         size: size,
         isCollection: true,
         mods: manifest.mods,
+        modVersions: manifest.modVersions,
         screenshotOffset: screenshotOffset,
         details: FrostyModDetails(
           manifest.title,

--- a/Packages/kyber_collection/lib/src/frosty/frosty_mod_reader.dart
+++ b/Packages/kyber_collection/lib/src/frosty/frosty_mod_reader.dart
@@ -216,6 +216,7 @@ class FrostyMod {
     this.dataOffset = 0,
     this.screenshotOffset = 0,
     this.mods,
+    this.modVersions,
     this.icon,
     this.customFrostyData,
   });
@@ -233,6 +234,7 @@ class FrostyMod {
   @Uint8ListConverter()
   Uint8List? icon;
   List<String>? mods;
+  List<String>? modVersions;
   FrostyModDetails details;
 
   Map<String, dynamic> toJson() => _$FrostyModToJson(this);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,7 +56,7 @@ melos:
         - mkdir "./Launcher/lib/gen/rust"
         - mkdir "./CLI/lib/src/gen"
         - dart pub global activate protoc_plugin 25.0.0
-        - cargo install flutter_rust_bridge_codegen
+        - cargo install flutter_rust_bridge_codegen@2.11.1
         - flutter pub global activate index_generator
 
   command:


### PR DESCRIPTION
Adds support for incremental mod updates in the launcher's download manager. Instead of re-downloading the full zip every time a mod is updated, the updater fetches only the files that changed and applies them to the existing install.

