### PR TITLE
[API, Launcher] feat: add bypass player limit entitlement

### DIFF
--- a/API/internal/rpc/client_server.go
+++ b/API/internal/rpc/client_server.go
@@ -101,7 +101,7 @@ func (s *ClientServer) CreateJoinToken(ctx context.Context, req *pbapi.JoinToken
 
 	isModerator := server.CanManage(host, user) || user.Entitled(models.EntitlementAdmin)
 	isFull := server.PlayerCount >= server.MaxPlayerCount
-	if !isModerator && isFull {
+	if !isModerator && !user.Entitled(models.EntitlementBypassPlayerLimit) && isFull {
 		return nil, status.Error(codes.ResourceExhausted, "Server is full")
 	}
 

--- a/API/pkg/models/user.go
+++ b/API/pkg/models/user.go
@@ -23,6 +23,7 @@ const (
 	EntitlementPatreonPerks            UserEntitlement = "PATREON_PERKS"
 	EntitlementDisableNameSync         UserEntitlement = "DISABLE_NAME_SYNC"
 	EntitlementAutoApproveModImages    UserEntitlement = "AUTO_APPROVE_MOD_IMAGES"
+	EntitlementBypassPlayerLimit       UserEntitlement = "BYPASS_PLAYER_LIMIT"
 	EntitlementUnknown                 UserEntitlement = "UNKNOWN"
 )
 

--- a/Launcher/lib/features/maxima/models/maxima_state.dart
+++ b/Launcher/lib/features/maxima/models/maxima_state.dart
@@ -79,6 +79,7 @@ enum UserEntitlement {
   verifiedServers,
   officialStats,
   patreonPerks,
+  bypassPlayerLimit,
 }
 
 UserEntitlement? parseUserEntitlement(String value) {
@@ -101,6 +102,8 @@ UserEntitlement? parseUserEntitlement(String value) {
       return .patreonPerks;
     case 'STAFF':
       return .staff;
+    case 'BYPASS_PLAYER_LIMIT':
+      return .bypassPlayerLimit;
     default:
       return null;
   }

--- a/Launcher/lib/features/server_browser/models/server_filter.dart
+++ b/Launcher/lib/features/server_browser/models/server_filter.dart
@@ -182,6 +182,9 @@ extension ServerBrowserExtension on Server {
 
     if (context == null) return true;
 
-    return !context.read<MaximaCubit>().state.isEntitled(.admin);
+    return !context.read<MaximaCubit>().state.isEntitledAny([
+      .admin,
+      .bypassPlayerLimit,
+    ]);
   }
 }


### PR DESCRIPTION
Adds a new `BYPASS_PLAYER_LIMIT` entitlement that lets granted users join servers at or above the max player count, matching the existing admin/moderator bypass.