### PR TITLE
[Launcher] fix: enable window drag across full title bar width

### DIFF
--- a/Launcher/lib/features/navigation_bar/widgets/action_bar.dart
+++ b/Launcher/lib/features/navigation_bar/widgets/action_bar.dart
@@ -7,15 +7,15 @@ class ActionBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const SizedBox(
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Spacer(),
-          RepaintBoundary(child: MaximaNavigationBarWidget()),
-          WindowButtons(),
-        ],
-      ),
+    return const Row(
+      mainAxisAlignment: .end,
+      crossAxisAlignment: .start,
+      children: [
+        RepaintBoundary(
+          child: MaximaNavigationBarWidget(),
+        ),
+        WindowButtons(),
+      ],
     );
   }
 }

--- a/Launcher/lib/features/navigation_bar/widgets/navigation_content.dart
+++ b/Launcher/lib/features/navigation_bar/widgets/navigation_content.dart
@@ -9,6 +9,7 @@ import 'package:kyber_launcher/features/navigation_bar/widgets/action_bar.dart';
 import 'package:kyber_launcher/features/navigation_bar/widgets/title_bar.dart'
     as kl;
 import 'package:kyber_launcher/shared/ui/navigation_bar/navigation_bar_list.dart';
+import 'package:window_manager/window_manager.dart';
 
 class NavigationContent extends StatelessWidget {
   const NavigationContent({
@@ -31,9 +32,11 @@ class NavigationContent extends StatelessWidget {
         child: Row(
           children: [
             Expanded(
-              child: Padding(padding: .only(left: 16), child: kl.TitleBar()),
+              child: DragToMoveArea(
+                child: Padding(padding: .only(left: 16), child: kl.TitleBar()),
+              ),
             ),
-            Expanded(child: ActionBar()),
+            ActionBar(),
           ],
         ),
       ),

--- a/Launcher/lib/features/navigation_bar/widgets/title_bar.dart
+++ b/Launcher/lib/features/navigation_bar/widgets/title_bar.dart
@@ -1,21 +1,18 @@
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:kyber_launcher/gen/assets.gen.dart';
-import 'package:window_manager/window_manager.dart';
 
 class TitleBar extends StatelessWidget {
   const TitleBar({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return DragToMoveArea(
-      child: Padding(
-        padding: const EdgeInsets.only(top: 10),
-        child: Row(
-          children: [
-            Assets.icons.betaIcon.svg(height: 20),
-            const Spacer(),
-          ],
-        ),
+    return Padding(
+      padding: const .only(top: 10),
+      child: Row(
+        children: [
+          Assets.icons.betaIcon.svg(height: 20),
+          const Spacer(),
+        ],
       ),
     );
   }


### PR DESCRIPTION
Fixes window dragging only working on the left half of the title bar