### PR TITLE
[Launcher] feat: warn on corrupted collections and prefer working duplicates

### DIFF
--- a/Launcher/lib/features/frosty/widgets/mod_icon.dart
+++ b/Launcher/lib/features/frosty/widgets/mod_icon.dart
@@ -1,14 +1,46 @@
+import 'dart:io';
+
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:kyber_collection/kyber_collection.dart';
+import 'package:kyber_launcher/features/mods/extensions/frosty_collection_extension.dart';
 import 'package:kyber_launcher/gen/assets.gen.dart';
+import 'package:kyber_launcher/shared/ui/elements/kyber_tooltip.dart';
 
-class ModIcon extends StatelessWidget {
+class ModIcon extends StatefulWidget {
   const ModIcon({this.mod, super.key});
 
   final FrostyMod? mod;
 
   @override
+  State<ModIcon> createState() => _ModIconState();
+}
+
+class _ModIconState extends State<ModIcon> {
+  bool _isCorrupted = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _isCorrupted = _checkCorrupted();
+  }
+
+  @override
+  void didUpdateWidget(ModIcon oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (!identical(oldWidget.mod, widget.mod)) {
+      _isCorrupted = _checkCorrupted();
+    }
+  }
+
+  bool _checkCorrupted() {
+    final mod = widget.mod;
+    return mod != null && mod.isCollection && mod.isCorrupted();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final mod = widget.mod;
     return Stack(
       clipBehavior: Clip.none,
       children: [
@@ -25,6 +57,20 @@ class ModIcon extends StatelessWidget {
               mod!.icon!,
               errorBuilder: (context, error, stackTrace) =>
                   const SizedBox.shrink(),
+            ),
+          ),
+        if (_isCorrupted)
+          Positioned.fill(
+            child: ColoredBox(
+              color: Colors.black.withOpacity(.5),
+              child: KyberTooltip(
+                message:
+                    'This collection is missing one or more of its mods.${Platform.lineTerminator}Reinstall it to fix.',
+                child: Icon(
+                  FluentIcons.warning,
+                  color: Colors.red,
+                ),
+              ),
             ),
           ),
       ],

--- a/Launcher/lib/features/kyber/helper/kyber_server_helper.dart
+++ b/Launcher/lib/features/kyber/helper/kyber_server_helper.dart
@@ -27,11 +27,18 @@ class KyberServerHelper {
     String? password,
   }) async {
     final localMods = sl.get<ModService>().mods;
-    final mods = server.mods.map(
-      (e) => localMods.firstWhere(
-        (element) => element.toKyberString() == '${e.name} (${e.version})',
-      ),
-    );
+    final mods = server.mods.map((e) {
+      final matches = localMods
+          .where(
+            (element) => element.toKyberString() == '${e.name} (${e.version})',
+          )
+          .toList();
+
+      return matches.firstWhereOrNull(
+            (m) => !m.isCollection || !m.isCorrupted(),
+          ) ??
+          matches.first;
+    });
     final collectionMods = <CollectionMod>[];
     for (final mod in mods) {
       if (mod.isCollection) {


### PR DESCRIPTION
Corrupted collections now show a small warning icon in the mod list. Joining a server now prefers a working copy of a collection over a corrupted one instead of failing