### PR TITLE
[Launcher] fix: handle unreachable proxies during load

### DIFF
--- a/Launcher/lib/features/kyber/helper/kyber_server_helper.dart
+++ b/Launcher/lib/features/kyber/helper/kyber_server_helper.dart
@@ -76,10 +76,13 @@ class KyberServerHelper {
       serverIp = '127.0.0.1';
     }
 
-    final proxies = navigatorKey.currentContext!
-        .read<KyberProxyCubit>()
-        .state
-        .proxies;
+    final proxyCubit = navigatorKey.currentContext!.read<KyberProxyCubit>();
+    if (proxyCubit.isLoading) {
+      NotificationService.info(message: 'Waiting for proxies to load...');
+    }
+
+    await proxyCubit.ensureReady();
+    final proxies = proxyCubit.state.proxies;
     var selectedProxy = proxies.firstWhereOrNull(
       (p) => p.proxy.id == Preferences.general.proxy,
     );

--- a/Launcher/lib/features/kyber/providers/kyber_proxy_cubit.dart
+++ b/Launcher/lib/features/kyber/providers/kyber_proxy_cubit.dart
@@ -22,12 +22,23 @@ class KyberProxyCubit extends Cubit<KyberProxyState> {
 
   final _logger = Logger('proxy_cubit');
 
+  Future<void>? _ready;
+  bool _loading = true;
+
+  bool get isLoading => _loading;
+
+  Future<void> ensureReady() => _ready ?? Future<void>.value();
+
   void selectProxy(String proxyId) {
     Preferences.general.proxy = proxyId;
     emit(state.copyWith(selectedProxy: proxyId));
   }
 
-  Future<void> loadProxies() async {
+  Future<void> loadProxies() {
+    return _ready = _loadProxies().whenComplete(() => _loading = false);
+  }
+
+  Future<void> _loadProxies() async {
     try {
       final resp = await sl.get<KyberGRPCService>().proxyClient.getList(
         Empty(),
@@ -45,8 +56,13 @@ class KyberProxyCubit extends Cubit<KyberProxyState> {
       final results = await Future.wait(
         proxyList.map(
           (p) async => pool.withResource(() async {
-            final ping = await _measurePing(p.ip);
-            return (info: p, ping: ping);
+            try {
+              final ping = await _measurePing(p.ip);
+              return (info: p, ping: ping);
+            } catch (e, s) {
+              _logger.warning('Ping failed for ${p.ip}', e, s);
+              return (info: p, ping: null);
+            }
           }),
         ),
       );
@@ -94,6 +110,7 @@ class KyberProxyCubit extends Cubit<KyberProxyState> {
       }
     } catch (e, s) {
       _logger.severe('Failed to load proxies', e, s);
+      emit(state.copyWith(proxies: [], selectedProxy: ''));
     }
   }
 
@@ -132,8 +149,12 @@ class KyberProxyCubit extends Cubit<KyberProxyState> {
       _logger.warning('Ping failed for $host: $e');
       return null;
     } finally {
-      await queue?.cancel();
-      await channel?.sink.close();
+      try {
+        await queue?.cancel();
+      } catch (_) {}
+      try {
+        await channel?.sink.close().timeout(_kPingTimeout);
+      } catch (_) {}
     }
   }
 


### PR DESCRIPTION
A single unreachable proxy left the whole proxy list empty, so users wouldn't be able to pick a proxy or join servers. Failed pings are now handled instead of leaving the entire proxy list empty, and joining a server now waits for the pings to finish (with a notification) instead of erroring with "no proxy available"