### PR TITLE
[Module, Launcher] feat: add code signing

### DIFF
--- a/.github/workflows/build-launcher.yml
+++ b/.github/workflows/build-launcher.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ${{ (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath') && 'windows-latest' || 'windows-latest-l' }}
+    runs-on: ${{ (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath') && 'windows-2022' || 'windows-latest-l' }}
 
     env:
       working-directory: ./Launcher

--- a/.github/workflows/build-launcher.yml
+++ b/.github/workflows/build-launcher.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: windows-latest-l
+    runs-on: windows-latest
 
     env:
       working-directory: ./Launcher
@@ -157,11 +157,89 @@ jobs:
         run: |
           cp "_work/vivoxsdk.dll" "build/windows/x64/runner/Release/vivoxsdk.dll"
 
+      - name: Stage binaries for signing
+        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath-launcher'
+        working-directory: ${{ env.working-directory }}
+        run: |
+          $release = "build/windows/x64/runner/Release"
+          New-Item -Path _signing -ItemType Directory -Force | Out-Null
+          Copy-Item "$release/kyber_launcher.exe" "_signing/kyber_launcher.exe"
+          Copy-Item "$release/rust_lib.dll" "_signing/rust_lib.dll"
+        shell: powershell
+
+      - name: Upload unsigned launcher artifact
+        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath-launcher'
+        id: upload-unsigned-launcher
+        uses: actions/upload-artifact@v4
+        with:
+          name: launcher-unsigned
+          path: ${{ env.working-directory }}/_signing/*
+
+      - name: Submit signing request
+        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath-launcher'
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: '${{ secrets.SIGNPATH_ORG_ID }}'
+          project-slug: 'kyber'
+          signing-policy-slug: 'release-signing'
+          artifact-configuration-slug: 'launcher-binaries'
+          github-artifact-id: '${{ steps.upload-unsigned-launcher.outputs.artifact-id }}'
+          wait-for-completion: true
+          output-artifact-directory: '${{ env.working-directory }}/_signed'
+          wait-for-completion-timeout-in-seconds: 1800
+
+      - name: Copy signed binaries back
+        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath-launcher'
+        working-directory: ${{ env.working-directory }}
+        run: |
+          $release = "build/windows/x64/runner/Release"
+          Copy-Item -Force "_signed/kyber_launcher.exe" "$release/kyber_launcher.exe"
+          Copy-Item -Force "_signed/rust_lib.dll" "$release/rust_lib.dll"
+        shell: powershell
+
       - name: Generate Installer
         uses: Minionguyjpro/Inno-Setup-Action@v1.2.7
         with:
           path: Launcher/installer/installer.iss
           options: /O+
+
+      - name: Stage installer for signing
+        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath-launcher'
+        working-directory: ${{ env.working-directory }}
+        run: |
+          New-Item -Path _signing_installer -ItemType Directory -Force | Out-Null
+          Copy-Item "installer/KyberLauncherInstaller.exe" "_signing_installer/KyberLauncherInstaller.exe"
+        shell: powershell
+
+      - name: Upload unsigned installer artifact
+        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath-launcher'
+        id: upload-unsigned-installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: installer-unsigned
+          path: ${{ env.working-directory }}/_signing_installer/*
+
+      - name: Submit installer signing request
+        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath-launcher'
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: '${{ secrets.SIGNPATH_ORG_ID }}'
+          project-slug: 'kyber'
+          signing-policy-slug: 'release-signing'
+          artifact-configuration-slug: 'installer'
+          github-artifact-id: '${{ steps.upload-unsigned-installer.outputs.artifact-id }}'
+          wait-for-completion: true
+          output-artifact-directory: '${{ env.working-directory }}/_signed_installer'
+          wait-for-completion-timeout-in-seconds: 1800
+
+      - name: Copy signed installer back
+        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath-launcher'
+        working-directory: ${{ env.working-directory }}
+        run: |
+          Copy-Item -Force "_signed_installer/KyberLauncherInstaller.exe" "installer/KyberLauncherInstaller.exe"
+        shell: powershell
 
       - name: Generate Version File
         run: |

--- a/.github/workflows/build-launcher.yml
+++ b/.github/workflows/build-launcher.yml
@@ -158,7 +158,7 @@ jobs:
           cp "_work/vivoxsdk.dll" "build/windows/x64/runner/Release/vivoxsdk.dll"
 
       - name: Stage binaries for signing
-        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath-launcher'
+        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath'
         working-directory: ${{ env.working-directory }}
         run: |
           $release = "build/windows/x64/runner/Release"
@@ -168,7 +168,7 @@ jobs:
         shell: powershell
 
       - name: Upload unsigned launcher artifact
-        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath-launcher'
+        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath'
         id: upload-unsigned-launcher
         uses: actions/upload-artifact@v4
         with:
@@ -176,7 +176,7 @@ jobs:
           path: ${{ env.working-directory }}/_signing/*
 
       - name: Submit signing request
-        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath-launcher'
+        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath'
         uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
@@ -190,7 +190,7 @@ jobs:
           wait-for-completion-timeout-in-seconds: 1800
 
       - name: Copy signed binaries back
-        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath-launcher'
+        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath'
         working-directory: ${{ env.working-directory }}
         run: |
           $release = "build/windows/x64/runner/Release"
@@ -205,7 +205,7 @@ jobs:
           options: /O+
 
       - name: Stage installer for signing
-        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath-launcher'
+        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath'
         working-directory: ${{ env.working-directory }}
         run: |
           New-Item -Path _signing_installer -ItemType Directory -Force | Out-Null
@@ -213,7 +213,7 @@ jobs:
         shell: powershell
 
       - name: Upload unsigned installer artifact
-        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath-launcher'
+        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath'
         id: upload-unsigned-installer
         uses: actions/upload-artifact@v4
         with:
@@ -221,7 +221,7 @@ jobs:
           path: ${{ env.working-directory }}/_signing_installer/*
 
       - name: Submit installer signing request
-        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath-launcher'
+        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath'
         uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
@@ -235,7 +235,7 @@ jobs:
           wait-for-completion-timeout-in-seconds: 1800
 
       - name: Copy signed installer back
-        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath-launcher'
+        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath'
         working-directory: ${{ env.working-directory }}
         run: |
           Copy-Item -Force "_signed_installer/KyberLauncherInstaller.exe" "installer/KyberLauncherInstaller.exe"

--- a/.github/workflows/build-launcher.yml
+++ b/.github/workflows/build-launcher.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ${{ (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath') && 'windows-latest' || 'windows-latest-l' }}
 
     env:
       working-directory: ./Launcher

--- a/.github/workflows/build-launcher.yml
+++ b/.github/workflows/build-launcher.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ${{ (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath') && 'windows-2022' || 'windows-latest-l' }}
+    runs-on: ${{ (github.ref == 'refs/heads/stable') && 'windows-2022' || 'windows-latest-l' }}
 
     env:
       working-directory: ./Launcher
@@ -161,7 +161,7 @@ jobs:
           cp "_work/vivoxsdk.dll" "build/windows/x64/runner/Release/vivoxsdk.dll"
 
       - name: Stage binaries for signing
-        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath'
+        if: github.ref == 'refs/heads/stable'
         working-directory: ${{ env.working-directory }}
         run: |
           $release = "build/windows/x64/runner/Release"
@@ -171,7 +171,7 @@ jobs:
         shell: powershell
 
       - name: Upload unsigned launcher artifact
-        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath'
+        if: github.ref == 'refs/heads/stable'
         id: upload-unsigned-launcher
         uses: actions/upload-artifact@v4
         with:
@@ -179,13 +179,13 @@ jobs:
           path: ${{ env.working-directory }}/_signing/*
 
       - name: Submit signing request
-        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath'
+        if: github.ref == 'refs/heads/stable'
         uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '${{ secrets.SIGNPATH_ORG_ID }}'
           project-slug: 'kyber'
-          signing-policy-slug: 'test-signing'
+          signing-policy-slug: 'release-signing'
           artifact-configuration-slug: 'launcher-binaries'
           github-artifact-id: '${{ steps.upload-unsigned-launcher.outputs.artifact-id }}'
           wait-for-completion: true
@@ -193,7 +193,7 @@ jobs:
           wait-for-completion-timeout-in-seconds: 1800
 
       - name: Copy signed binaries back
-        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath'
+        if: github.ref == 'refs/heads/stable'
         working-directory: ${{ env.working-directory }}
         run: |
           $release = "build/windows/x64/runner/Release"
@@ -208,7 +208,7 @@ jobs:
           options: /O+
 
       - name: Stage installer for signing
-        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath'
+        if: github.ref == 'refs/heads/stable'
         working-directory: ${{ env.working-directory }}
         run: |
           New-Item -Path _signing_installer -ItemType Directory -Force | Out-Null
@@ -216,7 +216,7 @@ jobs:
         shell: powershell
 
       - name: Upload unsigned installer artifact
-        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath'
+        if: github.ref == 'refs/heads/stable'
         id: upload-unsigned-installer
         uses: actions/upload-artifact@v4
         with:
@@ -224,13 +224,13 @@ jobs:
           path: ${{ env.working-directory }}/_signing_installer/*
 
       - name: Submit installer signing request
-        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath'
+        if: github.ref == 'refs/heads/stable'
         uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '${{ secrets.SIGNPATH_ORG_ID }}'
           project-slug: 'kyber'
-          signing-policy-slug: 'test-signing'
+          signing-policy-slug: 'release-signing'
           artifact-configuration-slug: 'installer'
           github-artifact-id: '${{ steps.upload-unsigned-installer.outputs.artifact-id }}'
           wait-for-completion: true
@@ -238,7 +238,7 @@ jobs:
           wait-for-completion-timeout-in-seconds: 1800
 
       - name: Copy signed installer back
-        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath'
+        if: github.ref == 'refs/heads/stable'
         working-directory: ${{ env.working-directory }}
         run: |
           Copy-Item -Force "_signed_installer/KyberLauncherInstaller.exe" "installer/KyberLauncherInstaller.exe"

--- a/.github/workflows/build-launcher.yml
+++ b/.github/workflows/build-launcher.yml
@@ -182,7 +182,7 @@ jobs:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '${{ secrets.SIGNPATH_ORG_ID }}'
           project-slug: 'kyber'
-          signing-policy-slug: 'release-signing'
+          signing-policy-slug: 'test-signing'
           artifact-configuration-slug: 'launcher-binaries'
           github-artifact-id: '${{ steps.upload-unsigned-launcher.outputs.artifact-id }}'
           wait-for-completion: true
@@ -227,7 +227,7 @@ jobs:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '${{ secrets.SIGNPATH_ORG_ID }}'
           project-slug: 'kyber'
-          signing-policy-slug: 'release-signing'
+          signing-policy-slug: 'test-signing'
           artifact-configuration-slug: 'installer'
           github-artifact-id: '${{ steps.upload-unsigned-installer.outputs.artifact-id }}'
           wait-for-completion: true

--- a/.github/workflows/build-module.yaml
+++ b/.github/workflows/build-module.yaml
@@ -99,7 +99,7 @@ jobs:
         if: startsWith(github.ref, 'refs/heads/ver/') || github.event_name == 'workflow_dispatch'
         working-directory: ${{env.working-directory}}
         run: |
-          cp "_signed/Kyber.dll" "_work/Kyber.dll"
+          cp -Force "_signed/Kyber.dll" "_work/Kyber.dll"
 
       - name: Zip files
         if: github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/heads/ver/') || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/build-module.yaml
+++ b/.github/workflows/build-module.yaml
@@ -89,7 +89,7 @@ jobs:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '${{ secrets.SIGNPATH_ORG_ID }}'
           project-slug: 'kyber'
-          signing-policy-slug: 'test-signing'
+          signing-policy-slug: 'module-signing-release'
           github-artifact-id: '${{ steps.upload-unsigned-artifact.outputs.artifact-id }}'
           wait-for-completion: true
           output-artifact-directory: '${{env.working-directory}}/_signed'

--- a/.github/workflows/build-module.yaml
+++ b/.github/workflows/build-module.yaml
@@ -96,7 +96,7 @@ jobs:
           wait-for-completion-timeout-in-seconds: 36288000
 
       - name: Copy DLL
-        if: startsWith(github.ref, 'refs/heads/ver/') || github.event_name == 'workflow_dispatch'
+        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath'
         working-directory: ${{env.working-directory}}
         run: |
           cp -Force "_signed/Kyber.dll" "_work/Kyber.dll"

--- a/.github/workflows/build-module.yaml
+++ b/.github/workflows/build-module.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest-large
+    runs-on: windows-latest-l
 
     env:
       working-directory: ./Module

--- a/.github/workflows/build-module.yaml
+++ b/.github/workflows/build-module.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ${{ (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath') && 'windows-latest' || 'windows-latest-l' }}
 
     env:
       working-directory: ./Module

--- a/.github/workflows/build-module.yaml
+++ b/.github/workflows/build-module.yaml
@@ -80,7 +80,7 @@ jobs:
         id: upload-unsigned-artifact
         uses: actions/upload-artifact@v4
         with:
-          path: bazel-bin/Kyber.dll
+          path: ${{env.working-directory}}/bazel-bin/Kyber.dll
 
       - id: optional_step_id
         if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath'
@@ -92,7 +92,7 @@ jobs:
           signing-policy-slug: 'test-signing'
           github-artifact-id: '${{ steps.upload-unsigned-artifact.outputs.artifact-id }}'
           wait-for-completion: true
-          output-artifact-directory: '_signed'
+          output-artifact-directory: '${{env.working-directory}}/_signed'
           wait-for-completion-timeout-in-seconds: 36288000
 
       - name: Copy DLL

--- a/.github/workflows/build-module.yaml
+++ b/.github/workflows/build-module.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest-l
+    runs-on: windows-latest
 
     env:
       working-directory: ./Module

--- a/.github/workflows/build-module.yaml
+++ b/.github/workflows/build-module.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build:
-    runs-on: blacksmith-16vcpu-windows-2025
+    runs-on: windows-latest-large
 
     env:
       working-directory: ./Module

--- a/.github/workflows/build-module.yaml
+++ b/.github/workflows/build-module.yaml
@@ -70,10 +70,36 @@ jobs:
         shell: powershell
 
       - name: Copy DLL
-        if: github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/heads/ver/') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/heads/ver/') || github.event_name == 'workflow_dispatch'
         working-directory: ${{env.working-directory}}
         run: |
           cp "bazel-bin/Kyber.dll" "_work/Kyber.dll"
+
+      - name: upload-unsigned-artifact
+        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath'
+        id: upload-unsigned-artifact
+        uses: actions/upload-artifact@v4
+        with:
+          path: bazel-bin/Kyber.dll
+
+      - id: optional_step_id
+        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath'
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: '${{ secrets.SIGNPATH_ORG_ID }}'
+          project-slug: 'kyber'
+          signing-policy-slug: 'test-signing'
+          github-artifact-id: '${{ steps.upload-unsigned-artifact.outputs.artifact-id }}'
+          wait-for-completion: true
+          output-artifact-directory: '_signed'
+          wait-for-completion-timeout-in-seconds: 36288000
+
+      - name: Copy DLL
+        if: startsWith(github.ref, 'refs/heads/ver/') || github.event_name == 'workflow_dispatch'
+        working-directory: ${{env.working-directory}}
+        run: |
+          cp "_signed/Kyber.dll" "_work/Kyber.dll"
 
       - name: Zip files
         if: github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/heads/ver/') || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/build-module.yaml
+++ b/.github/workflows/build-module.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath') && 'windows-latest' || 'windows-latest-l' }}
+    runs-on: ${{ (github.ref == 'refs/heads/stable') && 'windows-latest' || 'windows-latest-l' }}
 
     env:
       working-directory: ./Module
@@ -76,14 +76,14 @@ jobs:
           cp "bazel-bin/Kyber.dll" "_work/Kyber.dll"
 
       - name: upload-unsigned-artifact
-        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath'
+        if: github.ref == 'refs/heads/stable'
         id: upload-unsigned-artifact
         uses: actions/upload-artifact@v4
         with:
           path: ${{env.working-directory}}/bazel-bin/Kyber.dll
 
       - id: optional_step_id
-        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath'
+        if: github.ref == 'refs/heads/stable'
         uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
@@ -96,7 +96,7 @@ jobs:
           wait-for-completion-timeout-in-seconds: 36288000
 
       - name: Copy DLL
-        if: github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/feat/signpath'
+        if: github.ref == 'refs/heads/stable'
         working-directory: ${{env.working-directory}}
         run: |
           cp -Force "_signed/Kyber.dll" "_work/Kyber.dll"

--- a/.github/workflows/build-module.yaml
+++ b/.github/workflows/build-module.yaml
@@ -89,7 +89,7 @@ jobs:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '${{ secrets.SIGNPATH_ORG_ID }}'
           project-slug: 'kyber'
-          signing-policy-slug: 'module-signing-release'
+          signing-policy-slug: 'release-signing'
           github-artifact-id: '${{ steps.upload-unsigned-artifact.outputs.artifact-id }}'
           wait-for-completion: true
           output-artifact-directory: '${{env.working-directory}}/_signed'

--- a/README.md
+++ b/README.md
@@ -25,6 +25,27 @@ KYBER is developed using a monorepo structure and contains multiple projects and
 
 See [BUILDING.md](BUILDING.md) for build instructions.
 
+## Code signing policy
+
+<table>
+<tr>
+<td align="center"><img src="https://signpath.org/assets/favicon.png" width="40"></td>
+<td>Free code signing on Windows provided by <a href="https://signpath.io">SignPath.io</a>, certificate by <a href="https://signpath.org">SignPath Foundation</a></td>
+</tr>
+</table>
+
+**Team roles**
+
+All changes, including those from team members, require review and approval
+by another team member before being merged. No one can merge their own changes.
+
+- Reviewers: [@MagixGames](https://github.com/MagixGames), [@7reax](https://github.com/7reax)
+- Approvers: [@MagixGames](https://github.com/MagixGames), [@7reax](https://github.com/7reax)
+
+**Privacy**
+
+See the [KYBER Terms of Service](https://kyber.gg/about/tos/).
+
 ## Contributing
 
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.


### PR DESCRIPTION
Windows builds are now code-signed through SignPath.org. 

The launcher, installer, and module (Kyber.dll) binaries are now submitted for signing on the stable branch before being packaged and released. Also adds a code signing policy section to the README.