### PR TITLE
[API] fix: treat zero-duration bans as permanent

### DIFF
--- a/API/internal/rpc/server_management.go
+++ b/API/internal/rpc/server_management.go
@@ -287,7 +287,7 @@ func (s *ServerManagement) BanPlayer(ctx context.Context, req *pbapi.ServerBanPl
 	}
 
 	var expiresAt *time.Time
-	if req.Duration != nil {
+	if req.Duration != nil && req.GetDuration() > 0 {
 		expiresAt = new(time.Time)
 		*expiresAt = time.Now().Add(time.Duration(*req.Duration) * time.Second)
 	}


### PR DESCRIPTION
A ban duration of `0` was creating an instantly-expired ban. Zero/non-positive durations now produce a permanent ban