### PR TITLE
Fix Nexus downloads not extracting after API change

### DIFF
--- a/Launcher/lib/features/download_manager/services/download_link_resolver.dart
+++ b/Launcher/lib/features/download_manager/services/download_link_resolver.dart
@@ -26,7 +26,7 @@ class ResolvedDownload {
 class DownloadLinkResolver {
   DownloadLinkResolver({
     ModBridgeGRPCService? modBridgeService,
-  })  : _modBridgeService = modBridgeService ?? sl.get<ModBridgeGRPCService>();
+  }) : _modBridgeService = modBridgeService ?? sl.get<ModBridgeGRPCService>();
 
   final ModBridgeGRPCService _modBridgeService;
   final Logger _logger = Logger('download_link_resolver');
@@ -50,8 +50,16 @@ class DownloadLinkResolver {
   Future<ResolvedDownload> _resolveNxmLink(DownloadRequest request) async {
     try {
       final uri = Uri.parse(request.link);
-      final downloadUrl = await sl.get<NexusModsService>().generateDownloadLink(uri);
-      final filename = downloadUrl.split('/').last.split('?').first;
+      final downloadUrl = await sl.get<NexusModsService>().generateDownloadLink(
+        uri,
+      );
+      final filename =
+          request.filename ??
+          await NexusDownloadService.resolveNexusFileName(
+            modId: int.parse(uri.pathSegments[1]),
+            fileId: int.parse(uri.pathSegments.last),
+            urlFallback: downloadUrl,
+          );
 
       _logger.info('Resolved NXM link to: $filename');
 
@@ -88,7 +96,8 @@ class DownloadLinkResolver {
   }
 
   Future<ResolvedDownload> _resolveDirectLink(DownloadRequest request) async {
-    var filename = request.filename ?? request.link.split('/').last.split('?').first;
+    var filename =
+        request.filename ?? request.link.split('/').last.split('?').first;
     var size = request.size;
 
     if (filename.isEmpty || !filename.contains('.') || size == null) {

--- a/Launcher/lib/features/nexusmods/services/download_service.dart
+++ b/Launcher/lib/features/nexusmods/services/download_service.dart
@@ -41,7 +41,11 @@ class NexusDownloadService {
           );
 
       final downloadLink = Uri.parse(downloadLinks.first.uri);
-      final filename = downloadLink.pathSegments.last;
+      final filename = await resolveNexusFileName(
+        modId: int.parse(uri.pathSegments.last),
+        fileId: int.parse(uri.queryParameters['file_id']!),
+        urlFallback: downloadLink.toString(),
+      );
       return (downloadLink.toString(), filename);
     }
 
@@ -97,12 +101,12 @@ class NexusDownloadService {
         const .new(seconds: 15),
       );
 
-      final filename = uri
-          .split('/')
-          .last
-          .split('?')
-          .first
-          .replaceAll('%', '_');
+      final originalUri = Uri.parse(downloadUrl);
+      final filename = await resolveNexusFileName(
+        modId: int.parse(originalUri.pathSegments.last),
+        fileId: int.parse(originalUri.queryParameters['file_id']!),
+        urlFallback: uri,
+      );
 
       return (uri, filename);
     } on TimeoutException catch (e, s) {
@@ -134,5 +138,64 @@ class NexusDownloadService {
       Logger.root.info('Disposing WebView');
       await webView.dispose();
     }
+  }
+
+  static Future<String> resolveNexusFileName({
+    required int modId,
+    required int fileId,
+    required String urlFallback,
+  }) async {
+    final log = Logger('download_service');
+
+    try {
+      final apiClient = sl.get<NexusModsService>().nexusBridge.apiClient;
+      final modFiles = await apiClient.getModFiles(
+        'starwarsbattlefront22017',
+        modId,
+      );
+
+      final file = modFiles.files.firstWhere((f) => f.fileId == fileId);
+      if (file.fileName.isNotEmpty) {
+        return file.fileName;
+      }
+    } catch (e, s) {
+      log.warning(
+        'Could not resolve filename from Nexus API for file $fileId, '
+        'falling back to the download URL',
+        e,
+        s,
+      );
+    }
+
+    try {
+      final resp = await Dio().head<void>(urlFallback);
+      final disposition = resp.headers.value('content-disposition');
+
+      if (disposition != null) {
+        final match = RegExp('filename="?([^";]+)"?').firstMatch(disposition);
+        final filename = match?.group(1)?.trim();
+
+        if (filename != null) {
+          return _ensureArchiveExtension(filename);
+        }
+      }
+    } catch (_) {
+      // ignore and fall back to URL-based naming
+    }
+
+    final cleanUrl = urlFallback.split('?').first.split('/').last;
+    final fromUrl = cleanUrl.replaceAll('%', '_');
+
+    return _ensureArchiveExtension(fromUrl);
+  }
+
+  static String _ensureArchiveExtension(String name) {
+    const archiveExtensions = ['.zip', '.rar', '.7z'];
+    final lower = name.toLowerCase();
+
+    if (archiveExtensions.any(lower.endsWith)) {
+      return name;
+    }
+    return '$name.zip';
   }
 }


### PR DESCRIPTION
## Problem
Mod files download successfully from Nexus but fail to unpack into the mod collection directory. The downloaded file lands on disk without an archive extension, so extraction is skipped.

## Cause
On June 11th, 2026, Nexus switched the website and download back-end over to their new Upload API. As a result, CDN download URLs no longer contain the mod file's filename or extension in their path. This change is detailed by Nexus at https://forums.nexusmods.com/topic/13539100-changes-to-downloaded-file-names/. Since the launcher derived the filename from the URL path, the saved file had no archive extension, so `ArchiveExtractor.isArchive()` returned false and extraction was skipped.

## Fix
Resolve the filename from the Nexus V1 REST API (`getModFiles().file_name`), which still returns the correct filename with its extension, instead of scraping it from the URL. I also added a shared helper `NexusDownloadService.resolveNexusFileName` with a safe fallback chain:
- **Primary:** the file's `file_name` from the V1 API, matched by file ID
- **Fallback:** the filename provided in the download response headers
- **URL fallback:** the filename from the URL, with an archive extension added if one is missing

These fixes apply to both the in-app mod browser (premium API and non-premium webview branches) and the `nxm://` "Mod Manager Download" links on the Nexus website.

## Testing
The fix was verified against several mod files uploaded to Nexus after the Upload API change. The V1 API returned each file's `file_name` with its correct archive extension. Restoring that extension correctly allowed the extractor to unpack the download and add the file(s) to the mod directory, instead of skipping it. `dart analyze` is also clean for both modified files.