### PR TITLE
Fix bug with server Host/moderation UI where configured settings reset every 2m

### DIFF
--- a/Launcher/lib/features/kyber/providers/kyber_status_cubit.dart
+++ b/Launcher/lib/features/kyber/providers/kyber_status_cubit.dart
@@ -23,21 +23,27 @@ class KyberStatusCubit extends Cubit<KyberStatusState> {
         return;
       }
 
-      final state = await sl
+      final info = await sl
           .get<MaximaGameInstance>()
           .clientService
           .commonClient
           .getInfo(Empty());
-      if (!state.hasServer() && !state.client.hasServerId()) {
+      if (!info.hasServer() && !info.client.hasServerId()) {
         sl.get<RichPresence>().clearPresence();
         return;
       }
 
-      final id = state.hasServer() ? state.server.id : state.client.serverId;
+      final id = info.hasServer() ? info.server.id : info.client.serverId;
       final client = sl.get<KyberGRPCService>();
       final server = await client.serverBrowserClient.getServer(
         ServerRequest(id: id),
       );
+
+      // Refresh server metadata for the current state without transitioning
+      // out of it. `info` is a CommonState proto from getInfo(); it must not
+      // be confused with the cubit's `state`. Never emit KyberStatusNormal()
+      // from here — a transient/anomalous getInfo() result shouldn't tear
+      // down the hosted-server connection and reset all configured values.
       if (state is KyberStatusHosting) {
         emit(
           KyberStatusHosting(
@@ -53,11 +59,9 @@ class KyberStatusCubit extends Cubit<KyberStatusState> {
             joined: joined,
           ),
         );
-      } else {
-        emit(KyberStatusNormal());
       }
 
-      sl.get<RichPresence>().updatePresenceKyber(state, server);
+      sl.get<RichPresence>().updatePresenceKyber(info, server);
     });
   }
 

--- a/Launcher/lib/features/kyber/providers/kyber_status_cubit.dart
+++ b/Launcher/lib/features/kyber/providers/kyber_status_cubit.dart
@@ -108,6 +108,15 @@ class KyberStatusCubit extends Cubit<KyberStatusState> {
       } else if (data.hasServer()) {
         emit(KyberStatusHosting(serverState: data.server, server: server));
       } else {
+        // getInfo() reported no client and no server, but the game instance
+        // is still registered (we passed the isRegistered guard above).
+        // If we're already hosting or playing, stay in the current state
+        // rather than transitioning to Normal — a single anomalous
+        // getInfo() response shouldn't tear down the hosted-server
+        // connection and reset all configuration.
+        if (state is KyberStatusHosting || state is KyberStatusPlaying) {
+          return;
+        }
         emit(KyberStatusNormal());
       }
     } catch (e) {


### PR DESCRIPTION
### Problem
When hosting a server, the window periodically refreshes (roughly every 2 minutes). When this happens, it reloads the entire hosting/moderation UI twice (first time back to the server list page, second back to the current server) and on the second load all of the server settings.

### Replication steps

1. create a new server
2. Start the game
3. Configure bot settings, difficulty, etc (using the IOI mod) to be different from the default
4. Wait ~2m
5. Observe the double launcher UI reload and the settings reset back to the default values


https://github.com/user-attachments/assets/b54a3e4c-d9ab-487b-9e48-b62de690e10e



<details><summary>Debug logs</summary>
<p>

```
NFO - [client] - Updating RTM presence to 'null (1/4)'
INFO - [server_host] - Detected hosting status (17d282045b8d65cf5755b5310b6a399a)
INFO - [moderation_cubit] - Loading server 17d282045b8d65cf5755b5310b6a399a
INFO - [moderation_cubit] - Subscribing to server events
INFO - [moderation_cubit] - Fetching moderators
INFO - [moderation_cubit] - Fetching punishments
INFO - [client] - Updating RTM presence to 'null (1/4)'
--- this is where the configuration resets happen, requiring the next 2 lines to fix the UI state
INFO - [moderation_cubit] - Sending command: AutoPlayers.ForceFillGameplayBotsTeam2 22
INFO - [moderation_cubit] - Sending command: AutoPlayers.ForceFillGameplayBotsTeam1 9
```

</p>
</details> 

### The fix
- Double check the hosting state before returning to the server list screen, only return fully if not playing or hosting

### Testing
- original bug
  - Replicated the original error on my machine across multiple hosting sessions
- fix
  - Verified after multiple full sessions, no resets were observed
  - Verified after closing sessions, the redirect still functions correctly
  - Verified that when sitting at the host server browser screen it still periodically refreshes