### PR TITLE
feat: Mod browsing UX improvements

### DIFF
--- a/Launcher/lib/features/download_manager/services/download_orchestrator.dart
+++ b/Launcher/lib/features/download_manager/services/download_orchestrator.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'dart:isolate';
 import 'dart:ui';
@@ -213,30 +214,51 @@ class DownloadOrchestrator with ChangeNotifier {
         }
       }
 
-      final result = await FileDownloader().enqueue(
-        DownloadTask(
-          url: resolved.url,
-          directory:
-              '${Platform.isMacOS ? '/' : ''}${ModService.getBasePath()}',
-          filename: resolved.filename,
-          displayName: request.displayName,
-          updates: Updates.statusAndProgress,
-          retries: 1,
-          priority: request.priority,
-          allowPause: true,
-          baseDirectory: BaseDirectory.root,
-          metaData: _encodeMetadata(request.metadata),
-          options: TaskOptions(
-            beforeTaskStart: _onBeforeStart,
-            onTaskStart: _onTaskStart,
-            onTaskFinished: _onTaskDone,
-          ),
+      final downloadTask = DownloadTask(
+        url: resolved.url,
+        directory:
+            '${Platform.isMacOS ? '/' : ''}${ModService.getBasePath()}',
+        filename: resolved.filename,
+        displayName: request.displayName,
+        updates: Updates.statusAndProgress,
+        retries: 1,
+        priority: request.priority,
+        allowPause: true,
+        baseDirectory: BaseDirectory.root,
+        metaData: _encodeMetadata(request.metadata),
+        options: TaskOptions(
+          beforeTaskStart: _onBeforeStart,
+          onTaskStart: _onTaskStart,
+          onTaskFinished: _onTaskDone,
         ),
       );
+
+      final result = await FileDownloader().enqueue(downloadTask);
 
       if (!result) {
         NotificationService.error(message: 'Failed to queue download');
         return false;
+      }
+
+      // Notify listeners immediately so the cubit refreshes its task list.
+      // The background_downloader status callbacks may not fire for
+      // transitional states (enqueued/running), which previously caused
+      // the download manager UI to never show the download.
+      try {
+        final record = await FileDownloader().database.recordForId(
+          downloadTask.taskId,
+        );
+        if (record != null) {
+          _statusUpdates.add(
+            TaskStatusUpdate(
+              downloadTask,
+              record.status ?? TaskStatus.enqueued,
+            ),
+          );
+          notifyListeners();
+        }
+      } catch (e, s) {
+        _logger.warning('Failed to push initial status update', e, s);
       }
 
       _logger.info('Enqueued download: ${request.displayName}');
@@ -374,22 +396,28 @@ class DownloadOrchestrator with ChangeNotifier {
       'Task status update: ${update.task.taskId} - ${update.status}',
     );
 
-    if (update.status == .complete) {
-      await sl.isReady<ModService>();
-      await sl.get<ModService>().refresh();
+    try {
+      if (update.status == .complete) {
+        await sl.isReady<ModService>();
+        await sl.get<ModService>().refresh();
 
-      await _checkAndCancelDuplicates(update);
-    } else if (update.status == .failed) {
-      await _handleFailedDownload(update);
-    } else if (update.status == .running) {
-      await _platformIntegration.updateProgress(0);
-    }
+        await _checkAndCancelDuplicates(update);
+      } else if (update.status == .failed) {
+        await _handleFailedDownload(update);
+      } else if (update.status == .running) {
+        await _platformIntegration.updateProgress(0);
+      }
 
-    if (update.status == .canceled ||
-        update.status == .complete ||
-        update.status == .failed ||
-        update.status == .paused) {
-      await _platformIntegration.clear();
+      if (update.status == .canceled ||
+          update.status == .complete ||
+          update.status == .failed ||
+          update.status == .paused) {
+        await _platformIntegration.clear();
+      }
+    } catch (e, s) {
+      // Ensure exceptions in platform integration or side-effect handlers
+      // don't prevent the status update from reaching listeners.
+      _logger.warning('Error handling status update side-effects', e, s);
     }
 
     _statusUpdates.add(update);
@@ -401,8 +429,12 @@ class DownloadOrchestrator with ChangeNotifier {
       'Task progress: ${update.task.taskId} - ${(update.progress * 100).toStringAsFixed(1)}%',
     );
 
-    if (update.progress > 0 && update.progress < 1) {
-      await _platformIntegration.updateProgress(update.progress);
+    try {
+      if (update.progress > 0 && update.progress < 1) {
+        await _platformIntegration.updateProgress(update.progress);
+      }
+    } catch (e, s) {
+      _logger.warning('Error updating platform progress', e, s);
     }
 
     _progressUpdates.add(update);
@@ -423,15 +455,12 @@ class DownloadOrchestrator with ChangeNotifier {
       }
 
       try {
-        final mod = ServerMod.fromJson(task.task.metaData);
-        _logger.info(
-          'Processing queued download for ${mod.name} (${mod.version})',
-        );
+        final name = metadata['name'] as String? ?? '';
+        final version = metadata['version'] as String? ?? '';
+        _logger.info('Processing queued download for $name ($version)');
 
-        if (ModHelper.isInstalled(mod.name, mod.version)) {
-          _logger.info(
-            'Mod ${mod.name} is already installed. Skipping download.',
-          );
+        if (ModHelper.isInstalled(name, version)) {
+          _logger.info('Mod $name is already installed. Skipping download.');
           await FileDownloader().cancelTaskWithId(task.task.taskId);
         }
       } catch (e) {
@@ -476,11 +505,75 @@ class DownloadOrchestrator with ChangeNotifier {
       print('[${record.loggerName}] ${record.level.name}: ${record.message}');
     });
 
+    // Snapshot .fbmod files BEFORE extraction
+    final beforeFiles =
+        Directory(update.task.directory)
+            .listSync()
+            .whereType<File>()
+            .where((f) => extension(f.path) == '.fbmod' || extension(f.path) == '.fbfile')
+            .map((f) => basename(f.path))
+            .toSet();
+
     final postProcessor = DownloadPostProcessor();
     await postProcessor.processCompletedDownload(
       update,
       onProgress: onProgress,
     );
+
+    // Persist the NexusMods mod ID in a global manifest.
+    // Primary source: metadata (set by FileDownloadDialog).
+    try {
+      final metaDataStr = update.task.metaData;
+      var modId = _parseModIdFromMetadata(metaDataStr);
+
+      if (modId == null) {
+        final match = RegExp(r'/mods/(\d+)').firstMatch(update.task.url);
+        if (match != null) modId = int.tryParse(match.group(1)!);
+      }
+
+      if (modId == null) return;
+
+      final manifest = await ModService.readManifest();
+
+      final files = (manifest['files'] as Map<String, dynamic>?) ?? <String, dynamic>{};
+      final mods = (manifest['mods'] as Map<String, dynamic>?) ?? <String, dynamic>{};
+
+      final modMeta = _decodeMetadata(update.task.metaData);
+      final modTitle = modMeta?['name'] as String? ?? update.task.displayName;
+      final modVersion = modMeta?['version'] as String? ?? '';
+
+      mods[modId.toString()] = <String, dynamic>{
+        'title': modTitle,
+        'latestVersion': modVersion,
+        'lastDownloaded': DateTime.now().toIso8601String(),
+      };
+
+      // Snapshot AFTER extraction to find new .fbmod files
+      await Future.delayed(const Duration(milliseconds: 500));
+      final afterFiles =
+          Directory(update.task.directory)
+              .listSync()
+              .whereType<File>()
+              .where((f) => extension(f.path) == '.fbmod' || extension(f.path) == '.fbfile')
+              .map((f) => basename(f.path))
+              .toSet();
+
+      final newFiles = afterFiles.difference(beforeFiles);
+
+      if (newFiles.isEmpty) {
+        files[basename(update.task.filename)] = modId;
+      } else {
+        for (final file in newFiles) {
+          files[file] = modId;
+        }
+      }
+
+      manifest['files'] = files;
+      manifest['mods'] = mods;
+      await ModService.writeManifest(manifest);
+    } catch (_) {
+      // Non-critical — manifest is a best-effort cache
+    }
   }
 
   String _encodeMetadata(Map<String, dynamic>? metadata) {
@@ -495,19 +588,66 @@ class DownloadOrchestrator with ChangeNotifier {
         link: metadata['link'] as String? ?? '',
         fileSize: Int64(metadata['fileSize'] as int? ?? 0),
       );
-      return serverMod.writeToJson();
+      final result = <String, dynamic>{
+        'serverMod': serverMod.writeToJson(),
+      };
+      final modId = metadata['modId'];
+      if (modId != null) {
+        result['modId'] = modId;
+      }
+      return jsonEncode(result);
     } catch (e) {
       _logger.warning('Failed to encode metadata: $e');
       return '';
     }
   }
 
-  Map<String, dynamic>? _decodeMetadata(String metaDataString) {
+  /// Parses a mod ID from metadata. Handles new wrapper format
+  /// (`{"serverMod":..., "modId":2042}`) and legacy plain ServerMod JSON.
+  static int? _parseModIdFromMetadata(String metaDataString) {
+    if (metaDataString.isEmpty) return null;
+    try {
+      final decoded = jsonDecode(metaDataString);
+      if (decoded is Map<String, dynamic>) {
+        final modId = decoded['modId'];
+        if (modId != null) return (modId as num).toInt();
+        // Legacy format: try to parse as ServerMod and extract from link
+        if (decoded.containsKey('link')) {
+          final link = decoded['link'] as String? ?? '';
+          final match = RegExp(r'/mods/(\d+)').firstMatch(link);
+          if (match != null) return int.tryParse(match.group(1)!);
+        }
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  static Map<String, dynamic>? _decodeMetadata(String metaDataString) {
     if (metaDataString.isEmpty) {
       return null;
     }
 
     try {
+      // Try new wrapper format first: {"serverMod": "...", "modId": 2042}
+      final decoded = jsonDecode(metaDataString);
+      if (decoded is Map<String, dynamic> && decoded.containsKey('serverMod')) {
+        final serverMod = ServerMod.fromJson(decoded['serverMod'] as String);
+        final result = <String, dynamic>{
+          'name': serverMod.name,
+          'version': serverMod.version,
+          'link': serverMod.link,
+          'fileSize': serverMod.fileSize.toInt(),
+        };
+        final modId = decoded['modId'];
+        if (modId != null) result['modId'] = modId;
+        return result;
+      }
+    } catch (_) {
+      // Fall through to legacy format
+    }
+
+    try {
+      // Legacy format: plain ServerMod JSON
       final serverMod = ServerMod.fromJson(metaDataString);
       return {
         'name': serverMod.name,

--- a/Launcher/lib/features/mod_browser/dialogs/file_download_dialog.dart
+++ b/Launcher/lib/features/mod_browser/dialogs/file_download_dialog.dart
@@ -75,6 +75,12 @@ class _FileDownloadDialogState extends State<FileDownloadDialog> {
               link:
                   'https://www.nexusmods.com/starwarsbattlefront22017/mods/${widget.modId}?tab=files&file_id=${widget.file.fileId}',
               displayName: widget.file.name,
+              metadata: {
+                'name': widget.file.name,
+                'version': widget.file.version,
+                'modId': int.parse(widget.modId),
+                'fileSize': int.tryParse(widget.file.sizeInBytes ?? '0') ?? 0,
+              },
             );
 
             await sl.get<DownloadOrchestrator>().enqueueDownload(request);

--- a/Launcher/lib/features/mod_browser/screens/mod_details.dart
+++ b/Launcher/lib/features/mod_browser/screens/mod_details.dart
@@ -513,22 +513,16 @@ class _VersionFileGroup {
   int get totalFiles => files.length;
 }
 
-/// Groups files by (version, date) so files uploaded together in the same
-/// batch are displayed as a single versioned group. Expects input already
-/// sorted by date descending.
+/// Groups files by version so all files sharing the same version are
+/// displayed as a single group. Expects input already sorted by date
+/// descending (newest version first).
 List<_VersionFileGroup> _groupByVersionBatch(
   List<Query$modFiles$modFiles> files,
 ) {
   final groups = <_VersionFileGroup>[];
   for (final file in files) {
-    final version = file.version;
-    final date = file.date;
-    final category = file.category;
     final existing = groups.cast<_VersionFileGroup?>().firstWhere(
-      (g) =>
-          g!.version == version &&
-          g.date == date &&
-          g.category == category,
+      (g) => g!.version == file.version,
       orElse: () => null,
     );
     if (existing != null) {
@@ -536,9 +530,9 @@ List<_VersionFileGroup> _groupByVersionBatch(
     } else {
       groups.add(
         _VersionFileGroup(
-          version: version,
-          date: date,
-          category: category,
+          version: file.version,
+          date: file.date,
+          category: file.category,
           files: [file],
         ),
       );

--- a/Launcher/lib/features/mod_browser/screens/mod_details.dart
+++ b/Launcher/lib/features/mod_browser/screens/mod_details.dart
@@ -12,6 +12,7 @@ import 'package:kyber_launcher/features/mod_browser/widgets/mod_details/mod_desc
 import 'package:kyber_launcher/features/mod_browser/widgets/mod_image_viewer.dart';
 import 'package:kyber_launcher/features/mod_browser/widgets/nexus_mod_page/mod_author_info.dart';
 import 'package:kyber_launcher/features/mod_browser/widgets/nexus_mod_page/mod_header.dart';
+import 'package:kyber_launcher/features/mods/helper/mod_helper.dart';
 import 'package:kyber_launcher/features/nexusmods/services/nexusmods_service.dart';
 import 'package:kyber_launcher/features/nexusmods/widgets/graphql_provider.dart';
 import 'package:kyber_launcher/features/settings/dialogs/chromium_download_dialog.dart';
@@ -25,7 +26,6 @@ import 'package:kyber_launcher/shared/ui/utils/button_builder.dart';
 import 'package:logging/logging.dart';
 import 'package:nexus_bridge/nexus_bridge.dart';
 import 'package:nexus_gql/nexus_gql.dart';
-import 'package:super_sliver_list/super_sliver_list.dart';
 
 class ModInfo extends StatefulWidget {
   const ModInfo({required this.id, super.key});
@@ -428,17 +428,30 @@ class _ModInfoState extends State<ModInfo> {
                                 }
 
                                 final files = result.parsedData!.modFiles;
-                                final mainFiles = files
-                                    .where((e) => e.category == .MAIN)
+
+                                // Sort by date descending (newest first)
+                                final sorted = [...files]..sort(
+                                  (a, b) => b.date.compareTo(a.date),
+                                );
+
+                                // Group files by (version, date) — files with
+                                // the same version uploaded at the same time
+                                // are part of the same upload batch.
+                                final groups = _groupByVersionBatch(sorted);
+
+                                final mainFiles = groups
+                                    .where((g) => g.category == .MAIN)
                                     .toList();
-                                final optionalFiles = files
-                                    .where((e) => e.category == .OPTIONAL)
+                                final optionalFiles = groups
+                                    .where((g) => g.category == .OPTIONAL)
                                     .toList();
-                                final miscFiles = files
-                                    .where((e) => e.category == .MISCELLANEOUS)
+                                final miscFiles = groups
+                                    .where(
+                                      (g) => g.category == .MISCELLANEOUS,
+                                    )
                                     .toList();
-                                final archivedFiles = files
-                                    .where((e) => e.category == .ARCHIVED)
+                                final archivedFiles = groups
+                                    .where((g) => g.category == .ARCHIVED)
                                     .toList();
                                 return SingleChildScrollView(
                                   child: Column(
@@ -447,22 +460,22 @@ class _ModInfoState extends State<ModInfo> {
                                       _FileList(
                                         title: 'MAIN FILES',
                                         initialExpanded: true,
-                                        files: mainFiles,
+                                        groups: mainFiles,
                                       ),
                                       if (miscFiles.isNotEmpty)
                                         _FileList(
                                           title: 'MISCELLANEOUS FILES',
-                                          files: miscFiles,
+                                          groups: miscFiles,
                                         ),
                                       if (optionalFiles.isNotEmpty)
                                         _FileList(
                                           title: 'OPTIONAL FILES',
-                                          files: optionalFiles,
+                                          groups: optionalFiles,
                                         ),
                                       if (archivedFiles.isNotEmpty)
                                         _FileList(
                                           title: 'ARCHIVED FILES',
-                                          files: archivedFiles,
+                                          groups: archivedFiles,
                                         ),
                                     ],
                                   ),
@@ -483,16 +496,67 @@ class _ModInfoState extends State<ModInfo> {
   }
 }
 
+/// A group of mod files uploaded together as a version batch.
+class _VersionFileGroup {
+  _VersionFileGroup({
+    required this.version,
+    required this.date,
+    required this.category,
+    required this.files,
+  });
+
+  final String version;
+  final int date;
+  final Enum$ModFileCategory category;
+  final List<Query$modFiles$modFiles> files;
+
+  int get totalFiles => files.length;
+}
+
+/// Groups files by (version, date) so files uploaded together in the same
+/// batch are displayed as a single versioned group. Expects input already
+/// sorted by date descending.
+List<_VersionFileGroup> _groupByVersionBatch(
+  List<Query$modFiles$modFiles> files,
+) {
+  final groups = <_VersionFileGroup>[];
+  for (final file in files) {
+    final version = file.version;
+    final date = file.date;
+    final category = file.category;
+    final existing = groups.cast<_VersionFileGroup?>().firstWhere(
+      (g) =>
+          g!.version == version &&
+          g.date == date &&
+          g.category == category,
+      orElse: () => null,
+    );
+    if (existing != null) {
+      existing.files.add(file);
+    } else {
+      groups.add(
+        _VersionFileGroup(
+          version: version,
+          date: date,
+          category: category,
+          files: [file],
+        ),
+      );
+    }
+  }
+  return groups;
+}
+
 class _FileList extends StatefulWidget {
   const _FileList({
     required this.title,
-    required this.files,
+    required this.groups,
     this.initialExpanded = false,
   });
 
   final String title;
   final bool initialExpanded;
-  final List<Query$modFiles$modFiles> files;
+  final List<_VersionFileGroup> groups;
 
   @override
   State<_FileList> createState() => _FileListState();
@@ -500,6 +564,9 @@ class _FileList extends StatefulWidget {
 
 class _FileListState extends State<_FileList> {
   late bool _expanded;
+
+  int get totalFiles =>
+      widget.groups.fold(0, (sum, g) => sum + g.totalFiles);
 
   @override
   void initState() {
@@ -542,7 +609,7 @@ class _FileListState extends State<_FileList> {
                           vertical: 2.5,
                         ),
                         child: Text(
-                          '${widget.title.toUpperCase()} (${widget.files.length})',
+                          '${widget.title.toUpperCase()} ($totalFiles)',
                           style: const .new(
                             fontFamily: FontFamily.battlefrontUI,
                             fontSize: 15,
@@ -568,73 +635,157 @@ class _FileListState extends State<_FileList> {
         if (_expanded)
           ColoredBox(
             color: Colors.black.withOpacity(.4),
-            child: SuperListView.separated(
-              itemBuilder: (context, index) {
-                if (index == widget.files.length) {
-                  return const SizedBox.shrink();
-                }
-
-                final file = widget.files[index];
-                return ButtonBuilder(
-                  onClick: () {
-                    showKyberDialog(
-                      context: context,
-                      builder: (_) => FileDownloadDialog(
-                        file: file,
-                        modId: file.modId.toString(),
-                      ),
-                    );
-                  },
-                  builder: (context, hovered) {
-                    return AbsorbPointer(
-                      child: AnimatedDefaultTextStyle(
-                        duration: const .new(milliseconds: 150),
-                        style: TextStyle(
-                          fontFamily: FontFamily.battlefrontUI,
-                          color: hovered ? kActiveColor : kWhiteColor,
+            child: ListView.builder(
+              padding: .zero,
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              itemCount: widget.groups.length,
+              itemBuilder: (context, groupIndex) {
+                final group = widget.groups[groupIndex];
+                final formattedDate = DateFormat.yMd().add_jm().format(
+                  DateTime.fromMillisecondsSinceEpoch(group.date * 1000),
+                );
+                return Column(
+                  crossAxisAlignment: .stretch,
+                  children: [
+                    // Group header: version + date
+                    ColoredBox(
+                      color: Colors.white.withOpacity(.05),
+                      child: Padding(
+                        padding: const .symmetric(
+                          horizontal: 12,
+                          vertical: 6,
                         ),
-                        child: Container(
-                          padding: const .symmetric(
-                            horizontal: 12,
-                            vertical: 12,
-                          ),
-                          child: Row(
-                            children: [
-                              const Icon(
-                                FluentIcons.download,
-                                color: kWhiteColor,
-                                size: 20,
-                              ),
-                              const SizedBox(width: 10),
-                              Expanded(
-                                child: AutoSizeText(
-                                  file.name,
-                                  maxLines: 1,
-                                  minFontSize: 16,
-                                ),
-                              ),
-                              Text(
-                                formatBytes(
-                                  int.parse(file.sizeInBytes ?? '0'),
-                                  1,
-                                ),
+                        child: Row(
+                          children: [
+                            Expanded(
+                              child: Text(
+                                'v${group.version}',
                                 style: const .new(
+                                  fontFamily: FontFamily.battlefrontUI,
+                                  fontSize: 13,
                                   color: kGrayColor,
                                 ),
                               ),
-                            ],
-                          ),
+                            ),
+                            Text(
+                              formattedDate,
+                              style: const .new(
+                                fontFamily: FontFamily.battlefrontUI,
+                                fontSize: 11,
+                                color: kGrayColor,
+                              ),
+                            ),
+                          ],
                         ),
                       ),
-                    );
-                  },
+                    ),
+                    const ContainerSeparator(),
+                    // Individual files within the version group
+                    ...group.files.map((file) {
+                      final isInstalled = ModHelper.isInstalled(
+                        file.name,
+                        file.version,
+                      );
+                      return ButtonBuilder(
+                        onClick: () {
+                          showKyberDialog(
+                            context: context,
+                            builder: (_) => FileDownloadDialog(
+                              file: file,
+                              modId: file.modId.toString(),
+                            ),
+                          );
+                        },
+                        builder: (context, hovered) {
+                          return AbsorbPointer(
+                            child: AnimatedDefaultTextStyle(
+                              duration: const .new(milliseconds: 150),
+                              style: TextStyle(
+                                fontFamily: FontFamily.battlefrontUI,
+                                color: hovered ? kActiveColor : kWhiteColor,
+                              ),
+                              child: Container(
+                                padding: const .symmetric(
+                                  horizontal: 12,
+                                  vertical: 10,
+                                ),
+                                child: Row(
+                                  children: [
+                                    const SizedBox(width: 8),
+                                    Icon(
+                                      FluentIcons.download,
+                                      color:
+                                          isInstalled
+                                              ? kActiveColor.withOpacity(.6)
+                                              : kWhiteColor,
+                                      size: 18,
+                                    ),
+                                    const SizedBox(width: 8),
+                                    Expanded(
+                                      child: Column(
+                                        crossAxisAlignment: .start,
+                                        children: [
+                                          AutoSizeText(
+                                            file.name,
+                                            maxLines: 1,
+                                            minFontSize: 14,
+                                          ),
+                                          if (group.files.length > 1)
+                                            Text(
+                                              'Part of v${group.version} batch (${group.totalFiles} files)',
+                                              style: const .new(
+                                                fontSize: 10,
+                                                color: kGrayColor,
+                                              ),
+                                            ),
+                                        ],
+                                      ),
+                                    ),
+                                    if (isInstalled)
+                                      Container(
+                                        margin: const .only(right: 8),
+                                        padding: const .symmetric(
+                                          horizontal: 8,
+                                          vertical: 2,
+                                        ),
+                                        decoration: BoxDecoration(
+                                          color: kActiveColor.withOpacity(.15),
+                                          borderRadius: .circular(4),
+                                          border: .all(
+                                            color: kActiveColor.withOpacity(.3),
+                                          ),
+                                        ),
+                                        child: Text(
+                                          'INSTALLED',
+                                          style: .new(
+                                            fontSize: 10,
+                                            color: kActiveColor,
+                                            fontFamily:
+                                                FontFamily.battlefrontUI,
+                                          ),
+                                        ),
+                                      ),
+                                    Text(
+                                      formatBytes(
+                                        int.parse(file.sizeInBytes ?? '0'),
+                                        1,
+                                      ),
+                                      style: const .new(color: kGrayColor),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          );
+                        },
+                      );
+                    }),
+                    if (groupIndex < widget.groups.length - 1)
+                      const ContainerSeparator(),
+                  ],
                 );
               },
-              separatorBuilder: (context, index) => const ContainerSeparator(),
-              padding: .zero,
-              itemCount: widget.files.length + 1,
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
             ),
           ),
       ],

--- a/Launcher/lib/features/mod_browser/screens/mod_details.dart
+++ b/Launcher/lib/features/mod_browser/screens/mod_details.dart
@@ -727,7 +727,9 @@ class _FileListState extends State<_FileList> {
                                           ),
                                           if (group.files.length > 1)
                                             Text(
-                                              'Part of v${group.version} batch (${group.totalFiles} files)',
+                                              DateFormat.yMd().add_jm().format(
+                                                DateTime.fromMillisecondsSinceEpoch(group.date * 1000),
+                                              ),
                                               style: const .new(
                                                 fontSize: 10,
                                                 color: kGrayColor,

--- a/Launcher/lib/features/mod_browser/widgets/nmb_mod_tile.dart
+++ b/Launcher/lib/features/mod_browser/widgets/nmb_mod_tile.dart
@@ -3,6 +3,7 @@ import 'package:fluent_ui/fluent_ui.dart';
 import 'package:intl/intl.dart';
 import 'package:kyber_launcher/core/config/colors.dart';
 import 'package:kyber_launcher/core/routing/app_router.dart';
+import 'package:kyber_launcher/features/mods/helper/mod_helper.dart';
 import 'package:kyber_launcher/features/settings/dialogs/chromium_download_dialog.dart';
 import 'package:kyber_launcher/gen/assets.gen.dart';
 import 'package:kyber_launcher/gen/fonts.gen.dart';
@@ -87,6 +88,39 @@ class NMBModTile extends StatelessWidget {
                       fadeInDuration: Duration.zero,
                     ),
                   ),
+                ),
+                // Installed version badge
+                Builder(
+                  builder: (context) {
+                    final installedVersion =
+                        ModHelper.getInstalledVersion(mod.name);
+                    if (installedVersion == null) {
+                      return const SizedBox.shrink();
+                    }
+                    return Positioned(
+                      top: 8,
+                      right: 8,
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 8,
+                          vertical: 3,
+                        ),
+                        decoration: BoxDecoration(
+                          color: kActiveColor.withOpacity(.85),
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                        child: Text(
+                          'v$installedVersion',
+                          style: const TextStyle(
+                            fontSize: 10,
+                            fontWeight: FontWeight.bold,
+                            color: Colors.black,
+                            fontFamily: FontFamily.battlefrontUI,
+                          ),
+                        ),
+                      ),
+                    );
+                  },
                 ),
                 Positioned.fill(
                   child: AnimatedOpacity(

--- a/Launcher/lib/features/mods/helper/mod_helper.dart
+++ b/Launcher/lib/features/mods/helper/mod_helper.dart
@@ -32,6 +32,23 @@ class ModHelper {
     return false;
   }
 
+  /// Returns the installed version string if any version of the named mod
+  /// is installed, or `null` if none is installed.
+  static String? getInstalledVersion(String name) {
+    if (!sl.isReadySync<ModService>()) return null;
+
+    final service = sl.get<ModService>();
+
+    for (final mod in service.mods) {
+      if (mod.details.name == name) {
+        if (mod.isCollection && mod.isCorrupted()) continue;
+        return mod.details.version;
+      }
+    }
+
+    return null;
+  }
+
   static List<FrostyMod> getGameplayMods(List<FrostyMod> mods) {
     return mods
         .where(

--- a/Launcher/lib/features/mods/models/mod_list_group.dart
+++ b/Launcher/lib/features/mods/models/mod_list_group.dart
@@ -1,0 +1,23 @@
+import 'package:kyber_collection/kyber_collection.dart';
+
+/// A group of installed mods that share the same NexusMods mod ID.
+/// Mods not found in the manifest appear as individual groups
+/// with [title] and [modId] set to null.
+class ModListGroup {
+  const ModListGroup({
+    this.title,
+    this.modId,
+    this.latestVersion,
+    this.lastDownloaded,
+    required this.mods,
+  });
+
+  final String? title;
+  final int? modId;
+  final String? latestVersion;
+  final String? lastDownloaded;
+  final List<FrostyMod> mods;
+
+  String get displayName => title ?? mods.first.details.name;
+  bool get isNamed => title != null && modId != null;
+}

--- a/Launcher/lib/features/mods/providers/mod_list_cubit.dart
+++ b/Launcher/lib/features/mods/providers/mod_list_cubit.dart
@@ -1,6 +1,3 @@
-import 'dart:convert';
-import 'dart:io';
-
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:kyber_collection/kyber_collection.dart';
 import 'package:kyber_launcher/features/mods/constants/categories.dart';
@@ -75,7 +72,7 @@ class ModsListCubit extends Cubit<ModsListState> {
 
     final all = List<FrostyMod>.of(sl<ModService>().mods);
     final filtered = _applyFilter(all, filter);
-    final groups = _buildGroups(filtered);
+    final groups = await _buildGroups(filtered);
 
     emit(
       ModsListLoaded(
@@ -91,44 +88,23 @@ class ModsListCubit extends Cubit<ModsListState> {
   /// Groups mods by their NexusMods mod ID from the manifest.
   /// Mods not in the manifest remain as individual (unnamed) groups.
   /// Groups are sorted by title, interleaved with unnamed mods alphabetically.
-  List<ModListGroup> _buildGroups(List<FrostyMod> mods) {
+  Future<List<ModListGroup>> _buildGroups(List<FrostyMod> mods) async {
     // Read the manifest
-    Map<String, int> fileToModId;
-    Map<int, String> modIdToTitle;
-    Map<int, Map<String, dynamic>> modIdToMeta;
-    try {
-      final manifestFile = File(
-        join(ModService.getBasePath(), 'nexus_mod_manifest.json'),
-      );
-      if (manifestFile.existsSync()) {
-        final manifest =
-            jsonDecode(manifestFile.readAsStringSync()) as Map<String, dynamic>;
-        final files =
-            manifest['files'] as Map<String, dynamic>? ?? {};
-        final modEntries =
-            manifest['mods'] as Map<String, dynamic>? ?? {};
+    final manifest = await ModService.readManifest();
+    final files = manifest['files'] as Map<String, dynamic>? ?? {};
+    final modEntries = manifest['mods'] as Map<String, dynamic>? ?? {};
 
-        fileToModId = {};
-        for (final e in files.entries) {
-          fileToModId[e.key] = (e.value as num).toInt();
-        }
-        modIdToTitle = {};
-        modIdToMeta = {};
-        for (final e in modEntries.entries) {
-          final meta = e.value as Map<String, dynamic>?;
-          final id = int.parse(e.key);
-          modIdToTitle[id] = meta?['title'] as String? ?? '';
-          modIdToMeta[id] = meta ?? {};
-        }
-      } else {
-        fileToModId = {};
-        modIdToTitle = {};
-        modIdToMeta = {};
-      }
-    } catch (_) {
-      fileToModId = {};
-      modIdToTitle = {};
-      modIdToMeta = {};
+    final fileToModId = <String, int>{};
+    for (final e in files.entries) {
+      fileToModId[e.key] = (e.value as num).toInt();
+    }
+    final modIdToTitle = <int, String>{};
+    final modIdToMeta = <int, Map<String, dynamic>>{};
+    for (final e in modEntries.entries) {
+      final meta = e.value as Map<String, dynamic>?;
+      final id = int.parse(e.key);
+      modIdToTitle[id] = meta?['title'] as String? ?? '';
+      modIdToMeta[id] = meta ?? {};
     }
 
     // Group mods by modId; unmanifested mods go in their own bucket

--- a/Launcher/lib/features/mods/providers/mod_list_cubit.dart
+++ b/Launcher/lib/features/mods/providers/mod_list_cubit.dart
@@ -1,11 +1,16 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:kyber_collection/kyber_collection.dart';
 import 'package:kyber_launcher/features/mods/constants/categories.dart';
 import 'package:kyber_launcher/features/mods/extensions/frosty_collection_extension.dart';
 import 'package:kyber_launcher/features/mods/helper/frosty_mod_extension.dart';
+import 'package:kyber_launcher/features/mods/models/mod_list_group.dart';
 import 'package:kyber_launcher/features/mods/models/mods_filter.dart';
 import 'package:kyber_launcher/features/mods/services/mod_service.dart';
 import 'package:kyber_launcher/injection_container.dart';
+import 'package:path/path.dart';
 
 class ModsListCubit extends Cubit<ModsListState> {
   ModsListCubit() : super(const ModsListInitial()) {
@@ -42,6 +47,7 @@ class ModsListCubit extends Cubit<ModsListState> {
     emit(
       ModsListLoaded(
         mods: state.mods,
+        groups: state.groups,
         filter: state.filter,
         selectedMods: state.selectedMods,
         selectedMod: selectedMod,
@@ -53,6 +59,7 @@ class ModsListCubit extends Cubit<ModsListState> {
     emit(
       ModsListLoaded(
         mods: state.mods,
+        groups: state.groups,
         filter: state.filter,
         selectedMods: selectedMods,
         selectedMod: state.selectedMod,
@@ -68,15 +75,110 @@ class ModsListCubit extends Cubit<ModsListState> {
 
     final all = List<FrostyMod>.of(sl<ModService>().mods);
     final filtered = _applyFilter(all, filter);
+    final groups = _buildGroups(filtered);
 
     emit(
       ModsListLoaded(
         mods: filtered,
+        groups: groups,
         filter: filter,
         selectedMods: state.selectedMods,
         selectedMod: state.selectedMod,
       ),
     );
+  }
+
+  /// Groups mods by their NexusMods mod ID from the manifest.
+  /// Mods not in the manifest remain as individual (unnamed) groups.
+  /// Groups are sorted by title, interleaved with unnamed mods alphabetically.
+  List<ModListGroup> _buildGroups(List<FrostyMod> mods) {
+    // Read the manifest
+    Map<String, int> fileToModId;
+    Map<int, String> modIdToTitle;
+    Map<int, Map<String, dynamic>> modIdToMeta;
+    try {
+      final manifestFile = File(
+        join(ModService.getBasePath(), 'nexus_mod_manifest.json'),
+      );
+      if (manifestFile.existsSync()) {
+        final manifest =
+            jsonDecode(manifestFile.readAsStringSync()) as Map<String, dynamic>;
+        final files =
+            manifest['files'] as Map<String, dynamic>? ?? {};
+        final modEntries =
+            manifest['mods'] as Map<String, dynamic>? ?? {};
+
+        fileToModId = {};
+        for (final e in files.entries) {
+          fileToModId[e.key] = (e.value as num).toInt();
+        }
+        modIdToTitle = {};
+        modIdToMeta = {};
+        for (final e in modEntries.entries) {
+          final meta = e.value as Map<String, dynamic>?;
+          final id = int.parse(e.key);
+          modIdToTitle[id] = meta?['title'] as String? ?? '';
+          modIdToMeta[id] = meta ?? {};
+        }
+      } else {
+        fileToModId = {};
+        modIdToTitle = {};
+        modIdToMeta = {};
+      }
+    } catch (_) {
+      fileToModId = {};
+      modIdToTitle = {};
+      modIdToMeta = {};
+    }
+
+    // Group mods by modId; unmanifested mods go in their own bucket
+    final groupMap = <int, List<FrostyMod>>{};
+    final unmanifested = <FrostyMod>[];
+
+    for (final mod in mods) {
+      final lookupName = basename(mod.filename);
+      final modId = fileToModId[lookupName] ?? fileToModId[mod.filename];
+      if (modId != null) {
+        groupMap.putIfAbsent(modId, () => []).add(mod);
+      } else {
+        unmanifested.add(mod);
+      }
+    }
+
+    // Sort mods within each group alphabetically
+    for (final list in groupMap.values) {
+      list.sort((a, b) => a.details.name.compareTo(b.details.name));
+    }
+
+    // Build named groups, sorted by title
+    final groups = <ModListGroup>[];
+    final sortedIds = groupMap.keys.toList()
+      ..sort((a, b) {
+        final titleA = modIdToTitle[a] ?? '';
+        final titleB = modIdToTitle[b] ?? '';
+        return titleA.compareTo(titleB);
+      });
+
+    for (final id in sortedIds) {
+      final meta = modIdToMeta[id] ?? {};
+      groups.add(
+        ModListGroup(
+          title: modIdToTitle[id],
+          modId: id,
+          latestVersion: meta['latestVersion'] as String?,
+          lastDownloaded: meta['lastDownloaded'] as String?,
+          mods: groupMap[id]!,
+        ),
+      );
+    }
+
+    // Add unmanifested mods as individual groups, sorted by name
+    unmanifested.sort((a, b) => a.details.name.compareTo(b.details.name));
+    for (final mod in unmanifested) {
+      groups.add(ModListGroup(mods: [mod]));
+    }
+
+    return groups;
   }
 
   List<FrostyMod> _applyFilter(List<FrostyMod> mods, ModsFilter filter) {
@@ -130,12 +232,14 @@ sealed class ModsListState {
   const ModsListState({
     required this.filter,
     this.mods = const [],
+    this.groups = const [],
     this.selectedMods = const {},
     this.selectedMod,
   });
 
   final ModsFilter filter;
   final List<FrostyMod> mods;
+  final List<ModListGroup> groups;
   final Set<String> selectedMods;
   final FrostyMod? selectedMod;
 }
@@ -147,6 +251,7 @@ class ModsListInitial extends ModsListState {
 class ModsListLoaded extends ModsListState {
   const ModsListLoaded({
     required super.mods,
+    required super.groups,
     required super.filter,
     required super.selectedMods,
     required super.selectedMod,

--- a/Launcher/lib/features/mods/screens/mods.dart
+++ b/Launcher/lib/features/mods/screens/mods.dart
@@ -286,6 +286,7 @@ class _ModListView extends StatelessWidget {
 
     return ModList(
       mods: state.mods,
+      groups: state.groups,
       selectedMods: state.selectedMods,
       onModSelected: (mod) => onModSelected(mod, state, cubit),
       onModTap: cubit.setSelectedMod,

--- a/Launcher/lib/features/mods/services/mod_manifest_backfill_service.dart
+++ b/Launcher/lib/features/mods/services/mod_manifest_backfill_service.dart
@@ -1,6 +1,3 @@
-import 'dart:convert';
-import 'dart:io';
-
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:kyber_collection/kyber_collection.dart';
 import 'package:kyber_launcher/features/mods/services/mod_service.dart';
@@ -40,23 +37,8 @@ class ModManifestBackfillService {
         return;
       }
 
-      final manifestFile = File(
-        join(ModService.getBasePath(), 'nexus_mod_manifest.json'),
-      );
-
       // Read current manifest
-      Map<String, dynamic> manifest;
-      if (manifestFile.existsSync()) {
-        try {
-          manifest =
-              jsonDecode(manifestFile.readAsStringSync())
-                  as Map<String, dynamic>;
-        } catch (_) {
-          manifest = <String, dynamic>{};
-        }
-      } else {
-        manifest = <String, dynamic>{};
-      }
+      final manifest = await ModService.readManifest();
 
       final files =
           (manifest['files'] as Map<String, dynamic>?) ??
@@ -113,7 +95,7 @@ class ModManifestBackfillService {
           backfilled++;
           manifest['files'] = files;
           manifest['mods'] = mods;
-          manifestFile.writeAsStringSync(jsonEncode(manifest));
+          await ModService.writeManifest(manifest);
         }
       }
 
@@ -148,13 +130,13 @@ class ModManifestBackfillService {
     }.where((q) => q.isNotEmpty).toList();
 
     for (final query in queries) {
-      final result = await _trySearch(client, query, modName, installedVersion);
+      final result = await _searchModAndMatchVersion(client, query, modName, installedVersion);
       if (result != null) return result;
     }
     return null;
   }
 
-  static Future<int?> _trySearch(
+  static Future<int?> _searchModAndMatchVersion(
     GraphQLClient client,
     String query,
     String originalName,
@@ -224,7 +206,9 @@ class ModManifestBackfillService {
           continue;
         }
       }
-    } catch (_) {}
+    } catch (e) {
+      _log.fine('GQL search failed for query "$query": $e');
+    }
 
     return null;
   }

--- a/Launcher/lib/features/mods/services/mod_manifest_backfill_service.dart
+++ b/Launcher/lib/features/mods/services/mod_manifest_backfill_service.dart
@@ -1,0 +1,231 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:kyber_collection/kyber_collection.dart';
+import 'package:kyber_launcher/features/mods/services/mod_service.dart';
+import 'package:kyber_launcher/features/nexusmods/widgets/graphql_provider.dart';
+import 'package:logging/logging.dart';
+import 'package:nexus_gql/nexus_gql.dart';
+import 'package:path/path.dart';
+
+/// Runs a one-time backfill to populate [nexus_mod_manifest.json] for
+/// installed mods that were downloaded before the manifest system existed.
+///
+/// For each unmanifested mod, searches NexusMods by name, then
+/// cross-references file versions to find a deterministic match.
+/// Only writes an entry when exactly one mod matches both name AND version.
+class ModManifestBackfillService {
+  ModManifestBackfillService._();
+
+  static final _log = Logger('mod_manifest_backfill');
+
+  static bool _running = false;
+  static bool _hasRun = false;
+
+  /// Scans all installed mods and backfills any missing manifest entries.
+  /// Safe to call multiple times — skips if already running or already done.
+  /// Retries after a delay if the GQL client isn't ready yet.
+  static Future<void> backfillAll(List<FrostyMod> installedMods) async {
+    if (_running || _hasRun) return;
+    _running = true;
+
+    try {
+      final client = nexusGqlClient;
+      if (client == null) {
+        _running = false;
+        Future.delayed(const Duration(seconds: 3), () {
+          if (!_hasRun) backfillAll(installedMods);
+        });
+        return;
+      }
+
+      final manifestFile = File(
+        join(ModService.getBasePath(), 'nexus_mod_manifest.json'),
+      );
+
+      // Read current manifest
+      Map<String, dynamic> manifest;
+      if (manifestFile.existsSync()) {
+        try {
+          manifest =
+              jsonDecode(manifestFile.readAsStringSync())
+                  as Map<String, dynamic>;
+        } catch (_) {
+          manifest = <String, dynamic>{};
+        }
+      } else {
+        manifest = <String, dynamic>{};
+      }
+
+      final files =
+          (manifest['files'] as Map<String, dynamic>?) ??
+          <String, dynamic>{};
+      final mods =
+          (manifest['mods'] as Map<String, dynamic>?) ??
+          <String, dynamic>{};
+
+      // Build set of sub-mod filenames within collections — these
+      // don't have their own NexusMods entries, only the collection does.
+      final collectionSubMods = <String>{};
+      for (final mod in installedMods) {
+        if (mod.isCollection && mod.mods != null) {
+          for (final sub in mod.mods!) {
+            collectionSubMods.add(basename(sub));
+          }
+        }
+      }
+
+      // Find mods not in the manifest (check by basename).
+      // Skip sub-mods that belong to collections.
+      final unmanifested = <FrostyMod>[];
+      for (final mod in installedMods) {
+        final name = basename(mod.filename);
+        if (collectionSubMods.contains(name)) continue;
+        if (!files.containsKey(name)) {
+          if (!(manifest.containsKey(name) && manifest[name] is int)) {
+            unmanifested.add(mod);
+          }
+        }
+      }
+
+      _log.info(
+        'Backfilling ${unmanifested.length} mods '
+        '(skipped ${collectionSubMods.length} collection sub-mods)...',
+      );
+
+      if (unmanifested.isEmpty) {
+        _hasRun = true;
+        _running = false;
+        return;
+      }
+
+      var backfilled = 0;
+      for (final mod in unmanifested) {
+        final modId = await _resolveModId(client, mod);
+        if (modId != null) {
+          files[basename(mod.filename)] = modId;
+          mods[modId.toString()] = <String, dynamic>{
+            'title': mod.details.name,
+            'latestVersion': mod.details.version,
+            'lastDownloaded': DateTime.now().toIso8601String(),
+          };
+          backfilled++;
+          manifest['files'] = files;
+          manifest['mods'] = mods;
+          manifestFile.writeAsStringSync(jsonEncode(manifest));
+        }
+      }
+
+      _log.info(
+        'Backfill done: $backfilled matched, '
+        '${unmanifested.length - backfilled} unmatched '
+        '(of ${unmanifested.length} total)',
+      );
+      _hasRun = true;
+    } catch (e) {
+      _log.warning('Backfill error: $e');
+      _hasRun = true;
+    } finally {
+      _running = false;
+    }
+  }
+
+  /// Tries to deterministically resolve a mod's NexusMods ID by searching
+  /// by name then cross-referencing file versions. Returns null if not found.
+  static Future<int?> _resolveModId(
+    GraphQLClient client,
+    FrostyMod mod,
+  ) async {
+    final modName = mod.details.name;
+    final installedVersion = mod.details.version;
+
+    // Try full name first, then simplified variants
+    final queries = <String>{
+      modName,
+      modName.replaceAll(RegExp(r'\s*[-–]\s*Kyber(\s*Collection)?$'), ''),
+      modName.replaceAll(RegExp(r'\s+V\d[\d.]*$'), ''),
+    }.where((q) => q.isNotEmpty).toList();
+
+    for (final query in queries) {
+      final result = await _trySearch(client, query, modName, installedVersion);
+      if (result != null) return result;
+    }
+    return null;
+  }
+
+  static Future<int?> _trySearch(
+    GraphQLClient client,
+    String query,
+    String originalName,
+    String installedVersion,
+  ) async {
+    try {
+      final result = await client.query$searchMods(
+        .new(
+          variables: .new(
+            query: query,
+            sort: Input$ModsSort(
+              downloads: .new(direction: .DESC),
+            ),
+          ),
+        ),
+      );
+
+      if (result.hasException) return null;
+      if (result.parsedData == null) return null;
+
+      final nodes = result.parsedData!.mods.nodes;
+      if (nodes.isEmpty) return null;
+
+      // Match against the original mod name
+      final exactMatches = nodes
+          .where((n) => n.name.toLowerCase() == originalName.toLowerCase())
+          .toList();
+
+      if (exactMatches.isEmpty) {
+        // Fuzzy: mod name substring of top result (or vice versa)
+        if (nodes.isNotEmpty) {
+          final top = nodes.first.name.toLowerCase();
+          final q = originalName.toLowerCase();
+          if (top.contains(q) || q.contains(top)) {
+            return nodes.first.modId;
+          }
+        }
+        return null;
+      }
+
+      // If only one mod has this exact name, it's unambiguous — accept it
+      if (exactMatches.length == 1) {
+        return exactMatches.first.modId;
+      }
+
+      // Multiple mods share this name — cross-reference file versions
+      // to find a deterministic match
+      for (final candidate in exactMatches.take(3)) {
+        try {
+          final filesResult = await client.query$modFiles(
+            .new(
+              variables: .new(modId: candidate.modId.toString()),
+            ),
+          );
+          if (filesResult.hasException || filesResult.parsedData == null) {
+            continue;
+          }
+
+          final files = filesResult.parsedData!.modFiles;
+          final versionMatch = files.where(
+            (f) => f.version == installedVersion,
+          );
+          if (versionMatch.isNotEmpty) {
+            return candidate.modId;
+          }
+        } catch (_) {
+          continue;
+        }
+      }
+    } catch (_) {}
+
+    return null;
+  }
+}

--- a/Launcher/lib/features/mods/services/mod_service.dart
+++ b/Launcher/lib/features/mods/services/mod_service.dart
@@ -27,9 +27,6 @@ class ModService with ChangeNotifier {
     if (Preferences.general.setup) {
       watchDirectory();
     }
-
-    // Fire manifest backfill for pre-existing mods (retries until GQL ready)
-    ModManifestBackfillService.backfillAll(_mods);
   }
 
   static final Logger _logger = Logger('mod_service');
@@ -65,6 +62,44 @@ class ModService with ChangeNotifier {
 
   static Directory getBasePathAsDir() =>
       Directory(Preferences.general.modsPath);
+
+  /// Path to the shared mod manifest that maps installed mod filenames to
+  /// their NexusMods IDs and metadata.
+  static String get manifestPath =>
+      join(getBasePath(), 'nexus_mod_manifest.json');
+
+  /// Reads the mod manifest and returns it as a decoded map, or an empty map
+  /// if the file doesn't exist or is malformed.
+  static Future<Map<String, dynamic>> readManifest() async {
+    try {
+      final file = File(manifestPath);
+      if (!await file.exists()) return <String, dynamic>{};
+      final content = await file.readAsString();
+      return jsonDecode(content) as Map<String, dynamic>;
+    } catch (_) {
+      return <String, dynamic>{};
+    }
+  }
+
+  /// Reads the [section] from the manifest (e.g. 'files' or 'mods'),
+  /// returning an empty map if the section is missing or the manifest
+  /// can't be read.
+  static Future<Map<String, dynamic>> readManifestSection(
+    String section,
+  ) async {
+    final manifest = await readManifest();
+    return (manifest[section] as Map<String, dynamic>?) ?? <String, dynamic>{};
+  }
+
+  /// Writes the full manifest to disk. Merging/updating individual entries
+  /// is the caller's responsibility.
+  static Future<void> writeManifest(Map<String, dynamic> manifest) async {
+    try {
+      await File(manifestPath).writeAsString(jsonEncode(manifest));
+    } catch (e) {
+      _logger.warning('Failed to write mod manifest: $e');
+    }
+  }
 
   @override
   void dispose() {

--- a/Launcher/lib/features/mods/services/mod_service.dart
+++ b/Launcher/lib/features/mods/services/mod_service.dart
@@ -8,6 +8,7 @@ import 'package:kyber_launcher/core/services/app_settings.dart';
 import 'package:kyber_launcher/core/services/notification_service.dart';
 import 'package:kyber_launcher/features/mods/constants/categories.dart';
 import 'package:kyber_launcher/features/mods/services/level_declaration_service.dart';
+import 'package:kyber_launcher/features/mods/services/mod_manifest_backfill_service.dart';
 import 'package:kyber_launcher/injection_container.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart';
@@ -26,6 +27,9 @@ class ModService with ChangeNotifier {
     if (Preferences.general.setup) {
       watchDirectory();
     }
+
+    // Fire manifest backfill for pre-existing mods (retries until GQL ready)
+    ModManifestBackfillService.backfillAll(_mods);
   }
 
   static final Logger _logger = Logger('mod_service');
@@ -137,6 +141,10 @@ class ModService with ChangeNotifier {
     }
 
     notifyListeners();
+
+    // Fire-and-forget manifest backfill for pre-existing mods
+    _logger.info('Triggering manifest backfill for ${_mods.length} mods');
+    ModManifestBackfillService.backfillAll(_mods);
   }
 
   void watchDirectory() {

--- a/Launcher/lib/features/mods/widgets/mod_info_box.dart
+++ b/Launcher/lib/features/mods/widgets/mod_info_box.dart
@@ -103,42 +103,33 @@ class _ModInfoBoxState extends State<ModInfoBox> {
   /// If neither source provides an ID the button is hidden.
   Future<void> _resolveNexusModId() async {
     // 1. Check global manifest file
-    try {
-      final manifestFile = File(
-        join(ModService.getBasePath(), 'nexus_mod_manifest.json'),
-      );
-      if (await manifestFile.exists()) {
-        final manifest =
-            jsonDecode(await manifestFile.readAsString())
-                as Map<String, dynamic>;
-        final normalizedName = basename(widget.mod.filename);
-        final files = manifest['files'] as Map<String, dynamic>?;
-        final id = files != null
-            ? (files[widget.mod.filename] ?? files[normalizedName])
-            : (manifest[widget.mod.filename] ?? manifest[normalizedName]);
-        if (id != null) {
-          final modId = (id as num).toInt();
+    final manifest = await ModService.readManifest();
+    final normalizedName = basename(widget.mod.filename);
+    final files = manifest['files'] as Map<String, dynamic>?;
+    final id = files != null
+        ? (files[widget.mod.filename] ?? files[normalizedName])
+        : null;
+    if (id != null) {
+      final modId = (id as num).toInt();
+      if (mounted) setState(() => _nexusModId = modId);
+      _lookupDone = true;
+      return;
+    }
+    // Fallback: match by mod title in the "mods" section
+    final modsSection = manifest['mods'] as Map<String, dynamic>?;
+    if (modsSection != null) {
+      final modName = widget.mod.details.name;
+      for (final entry in modsSection.entries) {
+        final meta = entry.value as Map<String, dynamic>?;
+        final title = meta?['title'] as String? ?? '';
+        if (title.toLowerCase() == modName.toLowerCase()) {
+          final modId = int.parse(entry.key);
           if (mounted) setState(() => _nexusModId = modId);
           _lookupDone = true;
           return;
         }
-        // Fallback: match by mod title in the "mods" section
-        final modsSection = manifest['mods'] as Map<String, dynamic>?;
-        if (modsSection != null) {
-          final modName = widget.mod.details.name;
-          for (final entry in modsSection.entries) {
-            final meta = entry.value as Map<String, dynamic>?;
-            final title = meta?['title'] as String? ?? '';
-            if (title.toLowerCase() == modName.toLowerCase()) {
-              final modId = int.parse(entry.key);
-              if (mounted) setState(() => _nexusModId = modId);
-              _lookupDone = true;
-              return;
-            }
-          }
-        }
       }
-    } catch (_) {}
+    }
 
     // 2. Try extracting from the link field and backfill the manifest
     final link = widget.mod.details.link;
@@ -156,30 +147,14 @@ class _ModInfoBoxState extends State<ModInfoBox> {
   }
 
   /// Writes a resolved modId to the manifest so future lookups are instant.
-  void _writeManifestEntry(int modId) {
+  Future<void> _writeManifestEntry(int modId) async {
     try {
-      final manifestFile = File(
-        join(ModService.getBasePath(), 'nexus_mod_manifest.json'),
-      );
-      Map<String, dynamic> manifest;
-      if (manifestFile.existsSync()) {
-        try {
-          manifest =
-              jsonDecode(manifestFile.readAsStringSync())
-                  as Map<String, dynamic>;
-        } catch (_) {
-          manifest = <String, dynamic>{};
-        }
-      } else {
-        manifest = <String, dynamic>{};
-      }
+      final manifest = await ModService.readManifest();
 
       final files =
-          (manifest['files'] as Map<String, dynamic>?) ??
-          <String, dynamic>{};
+          (manifest['files'] as Map<String, dynamic>?) ?? <String, dynamic>{};
       final mods =
-          (manifest['mods'] as Map<String, dynamic>?) ??
-          <String, dynamic>{};
+          (manifest['mods'] as Map<String, dynamic>?) ?? <String, dynamic>{};
 
       files[basename(widget.mod.filename)] = modId;
       mods[modId.toString()] = <String, dynamic>{
@@ -191,10 +166,8 @@ class _ModInfoBoxState extends State<ModInfoBox> {
       manifest['files'] = files;
       manifest['mods'] = mods;
 
-      manifestFile.writeAsStringSync(jsonEncode(manifest));
-      _log.info(
-        'Backfilled manifest: ${widget.mod.filename} → $modId',
-      );
+      await ModService.writeManifest(manifest);
+      _log.info('Backfilled manifest: ${widget.mod.filename} → $modId');
     } catch (e) {
       _log.warning('Failed to write manifest entry: $e');
     }

--- a/Launcher/lib/features/mods/widgets/mod_info_box.dart
+++ b/Launcher/lib/features/mods/widgets/mod_info_box.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart' as mt;
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:kyber_collection/kyber_collection.dart';
 import 'package:kyber_launcher/core/config/colors.dart';
+import 'package:kyber_launcher/core/routing/app_router.dart';
 import 'package:kyber_launcher/features/mod_browser/widgets/mod_details/mod_images.dart';
 import 'package:kyber_launcher/features/mods/helper/frosty_mod_extension.dart';
 import 'package:kyber_launcher/features/mods/services/mod_service.dart';
@@ -17,6 +18,7 @@ import 'package:kyber_launcher/shared/ui/cards/kyber_container.dart';
 import 'package:kyber_launcher/shared/ui/elements/kyber_dropdown.dart';
 import 'package:kyber_launcher/shared/ui/utils/background_blur.dart';
 import 'package:kyber_launcher/shared/ui/utils/button_builder.dart';
+import 'package:logging/logging.dart';
 import 'package:path/path.dart';
 import 'package:super_sliver_list/super_sliver_list.dart';
 import 'package:url_launcher/url_launcher_string.dart';
@@ -32,9 +34,13 @@ class ModInfoBox extends StatefulWidget {
 }
 
 class _ModInfoBoxState extends State<ModInfoBox> {
+  static final _log = Logger('mod_info_box');
+
   List<Uint8List> screenshots = <Uint8List>[];
   Map<String, List<String>>? affectedFiles;
   bool affectedFilesExpanded = false;
+  int? _nexusModId;
+  bool _lookupDone = false;
 
   @override
   void initState() {
@@ -57,6 +63,7 @@ class _ModInfoBoxState extends State<ModInfoBox> {
         });
       }
     });
+    _resolveNexusModId();
     super.initState();
   }
 
@@ -80,7 +87,117 @@ class _ModInfoBoxState extends State<ModInfoBox> {
       });
     }
 
+    if (oldWidget.mod.details.name != widget.mod.details.name ||
+        oldWidget.mod.details.link != widget.mod.details.link) {
+      _nexusModId = null;
+      _lookupDone = false;
+      _resolveNexusModId();
+    }
+
     super.didUpdateWidget(oldWidget);
+  }
+
+  /// Resolves the NexusMods ID for this installed mod. Checks in order:
+  /// 1. Global `nexus_mod_manifest.json` (written at download time)
+  /// 2. Frosty mod `link` field → backfills manifest if found
+  /// If neither source provides an ID the button is hidden.
+  Future<void> _resolveNexusModId() async {
+    // 1. Check global manifest file
+    try {
+      final manifestFile = File(
+        join(ModService.getBasePath(), 'nexus_mod_manifest.json'),
+      );
+      if (await manifestFile.exists()) {
+        final manifest =
+            jsonDecode(await manifestFile.readAsString())
+                as Map<String, dynamic>;
+        final normalizedName = basename(widget.mod.filename);
+        final files = manifest['files'] as Map<String, dynamic>?;
+        final id = files != null
+            ? (files[widget.mod.filename] ?? files[normalizedName])
+            : (manifest[widget.mod.filename] ?? manifest[normalizedName]);
+        if (id != null) {
+          final modId = (id as num).toInt();
+          if (mounted) setState(() => _nexusModId = modId);
+          _lookupDone = true;
+          return;
+        }
+        // Fallback: match by mod title in the "mods" section
+        final modsSection = manifest['mods'] as Map<String, dynamic>?;
+        if (modsSection != null) {
+          final modName = widget.mod.details.name;
+          for (final entry in modsSection.entries) {
+            final meta = entry.value as Map<String, dynamic>?;
+            final title = meta?['title'] as String? ?? '';
+            if (title.toLowerCase() == modName.toLowerCase()) {
+              final modId = int.parse(entry.key);
+              if (mounted) setState(() => _nexusModId = modId);
+              _lookupDone = true;
+              return;
+            }
+          }
+        }
+      }
+    } catch (_) {}
+
+    // 2. Try extracting from the link field and backfill the manifest
+    final link = widget.mod.details.link;
+    if (link != null && link.isNotEmpty) {
+      final id = _extractNexusModId(link);
+      if (id != null) {
+        _writeManifestEntry(id);
+        if (mounted) setState(() => _nexusModId = id);
+        _lookupDone = true;
+        return;
+      }
+    }
+
+    _lookupDone = true;
+  }
+
+  /// Writes a resolved modId to the manifest so future lookups are instant.
+  void _writeManifestEntry(int modId) {
+    try {
+      final manifestFile = File(
+        join(ModService.getBasePath(), 'nexus_mod_manifest.json'),
+      );
+      Map<String, dynamic> manifest;
+      if (manifestFile.existsSync()) {
+        try {
+          manifest =
+              jsonDecode(manifestFile.readAsStringSync())
+                  as Map<String, dynamic>;
+        } catch (_) {
+          manifest = <String, dynamic>{};
+        }
+      } else {
+        manifest = <String, dynamic>{};
+      }
+
+      final files =
+          (manifest['files'] as Map<String, dynamic>?) ??
+          <String, dynamic>{};
+      final mods =
+          (manifest['mods'] as Map<String, dynamic>?) ??
+          <String, dynamic>{};
+
+      files[basename(widget.mod.filename)] = modId;
+      mods[modId.toString()] = <String, dynamic>{
+        'title': widget.mod.details.name,
+        'latestVersion': widget.mod.details.version,
+        'lastDownloaded': DateTime.now().toIso8601String(),
+      };
+
+      manifest['files'] = files;
+      manifest['mods'] = mods;
+
+      manifestFile.writeAsStringSync(jsonEncode(manifest));
+      _log.info(
+        'Backfilled manifest: ${widget.mod.filename} → $modId',
+      );
+    } catch (e) {
+      _log.warning('Failed to write manifest entry: $e');
+    }
   }
 
   Future<void> readAffectedFiles() async {
@@ -298,6 +415,25 @@ class _ModInfoBoxState extends State<ModInfoBox> {
                                     ),
                                   ],
                                 ),
+                              ),
+                              Builder(
+                                builder: (builderContext) {
+                                  final modId = _nexusModId;
+                                  if (modId == null) {
+                                    return const SizedBox.shrink();
+                                  }
+                                  return Padding(
+                                    padding: const EdgeInsets.only(left: 8),
+                                    child: KyberIconButton(
+                                      onPressed: () {
+                                        router.go(
+                                          '/mods/mod_browser/$modId',
+                                        );
+                                      },
+                                      iconData: mt.Icons.open_in_new,
+                                    ),
+                                  );
+                                },
                               ),
                             ],
                           ),
@@ -526,6 +662,16 @@ class _ModInfoBoxState extends State<ModInfoBox> {
       ),
     );
   }
+}
+
+/// Extracts the numeric mod ID from a NexusMods URL. Handles formats like:
+/// - https://www.nexusmods.com/starwarsbattlefront22017/mods/12345
+/// - https://www.nexusmods.com/starwarsbattlefront22017/mods/12345?tab=files
+/// Returns null if the URL doesn't match the expected pattern.
+int? _extractNexusModId(String url) {
+  final match =
+      RegExp(r'nexusmods\.com/\w+/mods/(\d+)').firstMatch(url);
+  return match != null ? int.tryParse(match.group(1)!) : null;
 }
 
 class _AffectedFileEntry {

--- a/Launcher/lib/features/mods/widgets/mod_list/mod_list.dart
+++ b/Launcher/lib/features/mods/widgets/mod_list/mod_list.dart
@@ -1,9 +1,18 @@
 import 'package:fluent_ui/fluent_ui.dart';
+import 'package:flutter/material.dart' as mt;
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:intl/intl.dart';
 import 'package:kyber_collection/kyber_collection.dart';
 import 'package:kyber_launcher/core/config/colors.dart';
+import 'package:kyber_launcher/core/routing/app_router.dart';
 import 'package:kyber_launcher/features/mods/helper/frosty_mod_extension.dart';
+import 'package:kyber_launcher/features/mods/models/mod_list_group.dart';
 import 'package:kyber_launcher/features/mods/services/mod_service.dart';
 import 'package:kyber_launcher/features/mods/widgets/mod_list/mod_list_entry.dart';
+import 'package:kyber_launcher/gen/fonts.gen.dart';
+import 'package:kyber_launcher/shared/ui/buttons/custom_icon_button.dart';
+import 'package:kyber_launcher/shared/ui/utils/button_builder.dart';
+import 'package:kyber_launcher/gen/assets.gen.dart';
 import 'package:kyber_launcher/injection_container.dart';
 
 class ModList extends StatefulWidget {
@@ -13,10 +22,12 @@ class ModList extends StatefulWidget {
     required this.activeMod,
     required this.onModTap,
     required this.selectedMods,
+    this.groups,
     super.key,
   });
 
   final List<FrostyMod> mods;
+  final List<ModListGroup>? groups;
   final FrostyMod? activeMod;
   final Set<String> selectedMods;
   final void Function(FrostyMod mod) onModTap;
@@ -30,6 +41,7 @@ class _ModListState extends State<ModList> {
   int? hoverIndex;
   int? expandedIndex;
   List<FrostyMod> expandedChildren = [];
+  final Set<int> _collapsedGroups = {};
 
   @override
   void initState() {
@@ -48,10 +60,19 @@ class _ModListState extends State<ModList> {
     }
   }
 
+  void _toggleGroup(int index) {
+    setState(() {
+      if (_collapsedGroups.contains(index)) {
+        _collapsedGroups.remove(index);
+      } else {
+        _collapsedGroups.add(index);
+      }
+    });
+  }
+
   Map<String, List<FrostyMod>> filterByCategory() {
     final mods = widget.mods;
     final filteredMods = <String, List<FrostyMod>>{};
-
     for (final mod in mods) {
       if (filteredMods.containsKey(mod.details.category)) {
         filteredMods[mod.details.category]!.add(mod);
@@ -59,7 +80,6 @@ class _ModListState extends State<ModList> {
         filteredMods[mod.details.category] = [mod];
       }
     }
-
     return filteredMods;
   }
 
@@ -77,6 +97,121 @@ class _ModListState extends State<ModList> {
 
   @override
   Widget build(BuildContext context) {
+    final groups = widget.groups;
+    if (groups != null && groups.isNotEmpty) {
+      return _buildGroupedList(groups);
+    }
+    return _buildFlatList();
+  }
+
+  Widget _buildGroupedList(List<ModListGroup> groups) {
+    // Build a flat index → (group, modIndexInGroup) mapping
+    final flatItems = <({ModListGroup group, int modIndex})>[];
+    for (final group in groups) {
+      if (group.isNamed && group.mods.length > 1) {
+        // Header slot (modIndex = -1)
+        flatItems.add((group: group, modIndex: -1));
+        if (!_collapsedGroups.contains(flatItems.length - 1)) {
+          for (var i = 0; i < group.mods.length; i++) {
+            flatItems.add((group: group, modIndex: i));
+          }
+        }
+      } else {
+        for (var i = 0; i < group.mods.length; i++) {
+          flatItems.add((group: group, modIndex: i));
+        }
+      }
+    }
+
+    return CustomScrollView(
+      slivers: [
+        SliverList(
+          delegate: SliverChildBuilderDelegate(
+            addAutomaticKeepAlives: false,
+            (context, index) {
+              final item = flatItems[index];
+              if (item.modIndex == -1) {
+                return _GroupHeader(
+                  group: item.group,
+                  collapsed: _collapsedGroups.contains(index),
+                  onTap: () => _toggleGroup(index),
+                );
+              }
+
+              final mod = item.group.mods[item.modIndex];
+              final indent = item.group.isNamed && item.group.mods.length > 1;
+              return _buildModWithChildren(mod, index, indent: indent);
+            },
+            childCount: flatItems.length,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildModWithChildren(FrostyMod mod, int idx, {bool indent = false}) {
+    final entry = GestureDetector(
+      onTap: () => widget.onModTap(mod),
+      child: ModListEntry(
+        mod: mod,
+        selected: widget.selectedMods.contains(mod.filename),
+        index: idx,
+        isLastSubItem: false,
+        hovered: hoverIndex == idx,
+        expanded: expandedIndex == idx,
+        onSelected: () => widget.onModSelected(mod),
+        onExpandCollection: () => toggleExpand(idx, mod),
+        onHover: (value) {
+          setState(() => hoverIndex = value ? idx : null);
+        },
+      ),
+    );
+
+    if ((expandedIndex == idx && expandedChildren.isNotEmpty) || indent) {
+      final children = <Widget>[];
+      if (indent) {
+        children.add(Padding(padding: const EdgeInsets.only(left: 24), child: entry));
+      } else {
+        children.add(entry);
+      }
+      if (expandedIndex == idx && expandedChildren.isNotEmpty) {
+        for (var i = 0; i < expandedChildren.length; i++) {
+          final child = expandedChildren[i];
+          children.add(
+            Padding(
+              padding: EdgeInsets.only(left: indent ? 24 : 0),
+              child: GestureDetector(
+                onTap: () => widget.onModTap(child),
+                child: ModListEntry(
+                  mod: child,
+                  selected: widget.selectedMods.contains(child.filename),
+                  index: idx + i + 1,
+                  isLastSubItem: i == expandedChildren.length - 1,
+                  subIndex: i,
+                  hovered: hoverIndex == idx + i + 1,
+                  expanded: false,
+                  onSelected: () => widget.onModSelected(child),
+                  onExpandCollection: () {},
+                  onHover: (value) {
+                    setState(() => hoverIndex = value ? idx + i + 1 : null);
+                  },
+                ),
+              ),
+            ),
+          );
+        }
+      }
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        mainAxisSize: MainAxisSize.min,
+        children: children,
+      );
+    }
+
+    return entry;
+  }
+
+  Widget _buildFlatList() {
     return CustomScrollView(
       slivers: [
         SliverList(
@@ -232,5 +367,129 @@ class _CustomBorder extends CustomPainter {
   @override
   bool shouldRepaint(covariant CustomPainter oldDelegate) {
     return true;
+  }
+}
+
+class _GroupHeader extends StatelessWidget {
+  const _GroupHeader({
+    required this.group,
+    required this.collapsed,
+    required this.onTap,
+  });
+
+  final ModListGroup group;
+  final bool collapsed;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final meta = <String>[];
+    if (group.latestVersion != null) {
+      meta.add('Latest: v${group.latestVersion}');
+    }
+    if (group.lastDownloaded != null) {
+      try {
+        final dt = DateTime.parse(group.lastDownloaded!);
+        meta.add(DateFormat.yMd().format(dt));
+      } catch (_) {}
+    }
+
+    return ButtonBuilder(
+      onClick: onTap,
+      builder: (context, hovered) {
+        return Container(
+          height: 38,
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          decoration: BoxDecoration(
+            color: Colors.white.withOpacity(.03),
+            border: Border.symmetric(
+              horizontal: BorderSide(
+                color: hovered ? kActiveColor : decoColor,
+                width: 1,
+              ),
+            ),
+          ),
+          child: Row(
+            children: [
+              SizedBox(
+                width: 24,
+                child: SvgPicture.asset(
+                  collapsed
+                      ? Assets.icons.kblDropdown.path
+                      : Assets.icons.kblDropdownFlipped.path,
+                  height: 10,
+                  width: 10,
+                  color: hovered ? kActiveColor : kInactiveColor,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text.rich(
+                  TextSpan(
+                    children: [
+                      TextSpan(
+                        text: group.displayName,
+                        style: TextStyle(
+                          fontFamily: FontFamily.battlefrontUI,
+                          fontSize: 14,
+                          color: kInactiveColor,
+                        ),
+                      ),
+                      TextSpan(
+                        text: '  (${group.mods.length} files',
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: FluentTheme.of(context)
+                              .typography
+                              .bodyLarge
+                              ?.color
+                              ?.withOpacity(.6),
+                        ),
+                      ),
+                      if (meta.isNotEmpty)
+                        TextSpan(
+                          text: ' · ${meta.join(' · ')})',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: FluentTheme.of(context)
+                                .typography
+                                .bodyLarge
+                                ?.color
+                                ?.withOpacity(.6),
+                          ),
+                        )
+                      else
+                        TextSpan(
+                          text: ')',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: FluentTheme.of(context)
+                                .typography
+                                .bodyLarge
+                                ?.color
+                                ?.withOpacity(.6),
+                          ),
+                        ),
+                    ],
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              if (group.modId != null) ...[
+                const SizedBox(width: 4),
+                KyberIconButton(
+                  onPressed: () {
+                    router.go('/mods/mod_browser/${group.modId}');
+                  },
+                  iconData: mt.Icons.open_in_new,
+                  size: 14,
+                ),
+              ],
+            ],
+          ),
+        );
+      },
+    );
   }
 }


### PR DESCRIPTION
### Problem
The Mod Browser & Installed Mod lists have a few papercut UX issues that make it difficult to reason about your installed mods. Some of the pain points are:

- One mod downloaded from the Mod Browser can result in multiple mods being added to the list, making it really tricky to remember/figure out which mods came from which Mod Browser listing after a while
- Once downloaded, there's not currently a way to go to the Mod Browser page for a given installed mod. This means that if you want to check for updates for a mod, you have to search and find the mod again
- When browsing mods to install in the Mod Browser, it's really difficult to figure out which versions of mod files are the latest ones, and which files correspond to a specific version. This means that if you have to use an older version of a mod, it's not currently possible to see which specific files correspond to that version (as opposed to an earlier version) or even which version is the next most recent to use (dates aren't shown either).
- [internal] we have no persisted metadata mapping downloaded & extracted mod files to their original mods, so any features that depend on this are not possible to build reliably

### Implemented Changes
This PR consists of multiple changes to try to improve these issues:
1. [internal]
  a. add a mod Manifest file & persistence handler that stores a mapping from mod files -> mod id, and also mod id -> mod metadata (title, last downloaded, etc). This acts as a source of truth for the current installed mods, and is not mandatory for all mods (all features built on this manifest are hidden when an entry is not detected)
  b. Also included (but not required) is a mod manifest backfill script to try to match up existing mod files to their nexusmods id
3. [UI]
  a. [Installed Mods] Groups the installed mod list by mod ID. When multiple mod files exist for the same mod present them as a collapsible group. When only one mod file exists, it maintains the current row UI
  b. [Installed Mods] Adds a button in the mod details pane (right side pane when a mod is selected) to go to the Mod Browser page for the selected mod (when the mod id is available via the manifest)
  c. [Mod Browser] Groups the mod files in the Mod Details pane (right side) by version, and adds the upload date in each row

Mod Browser details (grouped):
<img width="1920" height="1038" alt="kyber mod changes" src="https://github.com/user-attachments/assets/39dbd02d-5f52-4d16-a3c9-f8fc03c731c6" />


Mod list with grouped and ungrouped rows:

https://github.com/user-attachments/assets/1f7d319a-dcaa-4bcf-885e-d31732d06882


### Testing
- Verified that mods downloaded via the download manager persist the mod manifest file entries correctly
- Verified that mods with manifest entries and multiple files are grouped together correctly
- Verified that mods with manifest entries have a "Go to mod browser" button in their details pane, and that it navigates to the correct page
- Verified that mods without manifest entries still display correctly, are interactable, and do not show the new "Go to mod browser" button
- Verified that the mod backfill only runs once on app startup, that only mods without manifest entries are backfilled, and that mods where the heuristic-based matching fails do not break/crash/corrupt the app
- Verified that mod files are correctly grouped and sorted, and that upload dates are listed 
